### PR TITLE
Remove bogus symbol cass_cluster_set_queue_size_log.

### DIFF
--- a/cassandra.h
+++ b/cassandra.h
@@ -1002,21 +1002,22 @@ CASS_EXPORT CassError
 cass_cluster_set_queue_size_event(CassCluster* cluster,
                                   unsigned queue_size);
 
-/**
- * Sets the size of the fixed size queue that stores
- * log messages.
- *
- * <b>Default:</b> 8192
- *
- * @public @memberof CassCluster
- *
- * @param[in] cluster
- * @param[in] queue_size
- * @return CASS_OK if successful, otherwise an error occurred.
- */
-CASS_EXPORT CassError
-cass_cluster_set_queue_size_log(CassCluster* cluster,
-                                unsigned queue_size);
+// CPP-473 this symbol does not exist
+///**
+// * Sets the size of the fixed size queue that stores
+// * log messages.
+// *
+// * <b>Default:</b> 8192
+// *
+// * @public @memberof CassCluster
+// *
+// * @param[in] cluster
+// * @param[in] queue_size
+// * @return CASS_OK if successful, otherwise an error occurred.
+// */
+//CASS_EXPORT CassError
+//cass_cluster_set_queue_size_log(CassCluster* cluster,
+//                                unsigned queue_size);
 
 /**
  * Sets the number of connections made to each server in each

--- a/src/cassandra.rs
+++ b/src/cassandra.rs
@@ -507,9 +507,10 @@ extern "C" {
                                              queue_size:
                                                  ::std::os::raw::c_uint)
      -> CassError;
-    pub fn cass_cluster_set_queue_size_log(cluster: *mut CassCluster,
-                                           queue_size: ::std::os::raw::c_uint)
-     -> CassError;
+// CPP-473 this symbol does not exist
+//    pub fn cass_cluster_set_queue_size_log(cluster: *mut CassCluster,
+//                                           queue_size: ::std::os::raw::c_uint)
+//     -> CassError;
     pub fn cass_cluster_set_core_connections_per_host(cluster:
                                                           *mut CassCluster,
                                                       num_connections:


### PR DESCRIPTION
Per CPP-473, this symbol does not exist and its presence in
cassandra.h is an error.  This commit removes it, so it is not
exported by the Rust binding.

https://datastax-oss.atlassian.net/browse/CPP-473