### PR TITLE
Verify that all new commits are signed off.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,17 @@ before_script:
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:/usr/local/bin:$PATH
 
+# Enforce that all new commits are signed off according to the DCO,
+# per CONTRIBUTING.md. Prior commits are either pre-fork, are signed off,
+# or were made by Keith Wansbrough, who hereby certifies the DCO with regard
+# to each such commit.
+#
+# We then build all the code, then test it.
 script:
 - |
+  DCO_SIGNING_BASE_COMMIT=f43fa8aeac397cfbd4a470f506581948e807013c &&
+  if git log ${DCO_SIGNING_BASE_COMMIT}.. --grep "^signed-off-by: .\+@.\+" --regexp-ignore-case --invert-grep --no-merges | grep ^ ;
+  then echo '**One or more commits are not signed off!' ; /bin/false ; fi &&
   cargo build &&
   cargo test
 


### PR DESCRIPTION
Add code to CI script to enforce the presence of the `Signed-off-by:` line in all non-merge commits, as required by this repository's policy and explained in CONTRIBUTING.md.

Strangely similar to https://github.com/Metaswitch/cassandra-rs/pull/16 :-)