### PR TITLE
Bump version ready for changes post 0.12.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.13.0 (Unreleased)
+
 ## 0.12.0 (2018-11-30)
 * Upgraded cassandra-cpp-driver to 2.10.0 to get Datastax's fix for CPP-499
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["Cassandra", "binding", "CQL", "client", "database" ]
 categories = [ "api-bindings", "database", "external-ffi-bindings" ]
 license = "Apache-2.0"
 name = "cassandra-cpp-sys"
-version = "0.12.0"
+version = "0.13.0-pre"
 authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wansbrough@metaswitch.com>"]
 build = "build.rs"
 


### PR DESCRIPTION
Bump the version to 0.13.0-pre ready for changes post 0.12.0.