### PR TITLE
Fix compiling on macos

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("cargo:rustc-flags=-l dylib=cassandra");
     println!("cargo:rustc-flags=-l dylib=crypto");
     println!("cargo:rustc-flags=-l dylib=ssl");
-    println!("cargo:rustc-flags=-l dylib=stdc++");
+    println!("cargo:rustc-flags=-l dylib=c++");
     println!("cargo:rustc-flags=-l dylib=uv");
     println!("cargo:rustc-link-search={}", "/usr/lib/x86_64-linux-gnu");
     println!("cargo:rustc-link-search={}", "/usr/local/lib/x86_64-linux-gnu");
@@ -16,4 +16,6 @@ fn main() {
     println!("cargo:rustc-link-search={}", "/usr/local/lib");
     println!("cargo:rustc-link-search={}", "/usr/lib64/");
     println!("cargo:rustc-link-search={}", "/usr/lib/");
+    println!("cargo:rustc-link-search={}", "/usr/local/opt/openssl/lib");
+    
 }

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,10 @@ fn main() {
     println!("cargo:rustc-flags=-l dylib=cassandra");
     println!("cargo:rustc-flags=-l dylib=crypto");
     println!("cargo:rustc-flags=-l dylib=ssl");
+    #[cfg(target_os = "macos")]
     println!("cargo:rustc-flags=-l dylib=c++");
+    #[cfg(not(target_os = "macos"))]
+    println!("cargo:rustc-flags=-l dylib=stdc++");
     println!("cargo:rustc-flags=-l dylib=uv");
     println!("cargo:rustc-link-search={}", "/usr/lib/x86_64-linux-gnu");
     println!("cargo:rustc-link-search={}", "/usr/local/lib/x86_64-linux-gnu");

--- a/build.rs
+++ b/build.rs
@@ -17,5 +17,4 @@ fn main() {
     println!("cargo:rustc-link-search={}", "/usr/lib64/");
     println!("cargo:rustc-link-search={}", "/usr/lib/");
     println!("cargo:rustc-link-search={}", "/usr/local/opt/openssl/lib");
-    
 }


### PR DESCRIPTION
# Description

👋 

There were two changes required to get this compiling on macos.

1. Use `c++` instead of `stdc++`. New versions of xcode do not ship `stdc++` because it was deprecated long ago.
2. Search for ssl related libraries in `/usr/local/opt/openssl/lib`. This is where macos stores the required libraries.

I also made the changes to `cassandra-rs` and can put up a PR for that if this looks good.

# Contributing
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Signed-off-by: Jesse Howarth <jahowarth@gmail.com>
