### PR TITLE
Add `links` to `package` section of Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+* `links` manifest key was added for customized build
+
 ### Changed
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 name = "cassandra-cpp-sys"
 version = "0.12.1"
 authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wansbrough@metaswitch.com>"]
+links = "cassandra"
 build = "build.rs"
 
 [badges]


### PR DESCRIPTION
I'm developing on windows so I'd like to customize link options to suite my env, using [overriding build script feature](https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts).

With this change, I can have my local Cargo config for linking cassandra driver like:

```
[target.x86_64-pc-windows-msvc.cassandra]
rustc-link-lib = ["..."]
```