### PR TITLE
Support unsigned char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+* Remove assumption that char is signed. Allows building on M1.
 
 ## [0.12.2] - 2020-09-16
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,10 @@ fn main() {
     println!("cargo:rustc-flags=-l dylib=stdc++");
     println!("cargo:rustc-flags=-l dylib=uv");
     println!("cargo:rustc-link-search={}", "/usr/lib/x86_64-linux-gnu");
-    println!("cargo:rustc-link-search={}", "/usr/local/lib/x86_64-linux-gnu");
+    println!(
+        "cargo:rustc-link-search={}",
+        "/usr/local/lib/x86_64-linux-gnu"
+    );
     println!("cargo:rustc-link-search={}", "/usr/local/lib64");
     println!("cargo:rustc-link-search={}", "/usr/local/lib");
     println!("cargo:rustc-link-search={}", "/usr/lib64/");

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -13,20 +13,26 @@ static NUM_CONCURRENT_REQUESTS: usize = 1000;
 
 fn insert_into_async(session: &mut CassSession, key: &str) {
     unsafe {
-        let query = CString::new("INSERT INTO async (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);")
-            .unwrap()
-            .as_ptr();
+        let query = CString::new(
+            "INSERT INTO async (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);",
+        )
+        .unwrap()
+        .as_ptr();
         let futures = &mut Vec::with_capacity(NUM_CONCURRENT_REQUESTS);
 
         for i in 0..NUM_CONCURRENT_REQUESTS {
             let statement = cass_statement_new(query, 6);
 
-            cass_statement_bind_string(statement,
-                                       0,
-                                       CString::new(format!("{}{}", key, i)).unwrap().as_ptr());
-            cass_statement_bind_bool(statement,
-                                     1,
-                                     if i % 2 == 0 { cass_true } else { cass_false });
+            cass_statement_bind_string(
+                statement,
+                0,
+                CString::new(format!("{}{}", key, i)).unwrap().as_ptr(),
+            );
+            cass_statement_bind_bool(
+                statement,
+                1,
+                if i % 2 == 0 { cass_true } else { cass_false },
+            );
             cass_statement_bind_float(statement, 2, i as f32 / 2.0f32);
             cass_statement_bind_double(statement, 3, i as f64 / 200.0);
             cass_statement_bind_int32(statement, 4, i as i32 * 10);
@@ -56,10 +62,12 @@ pub fn main() {
 
         match connect_session(session, &cluster) {
             Ok(()) => {
-                execute_query(session,
-                              "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
-                               'SimpleStrategy', 'replication_factor': '3' };")
-                    .unwrap();
+                execute_query(
+                    session,
+                    "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
+                               'SimpleStrategy', 'replication_factor': '3' };",
+                )
+                .unwrap();
 
                 execute_query(session,
                               "CREATE TABLE IF NOT EXISTS examples.async (key text, bln boolean, flt float, dbl \

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -18,10 +18,16 @@ struct Basic {
     i64: i64,
 }
 
-fn insert_into_basic(session: &mut CassSession, key: &str, basic: &mut Basic) -> Result<(), CassError> {
+fn insert_into_basic(
+    session: &mut CassSession,
+    key: &str,
+    basic: &mut Basic,
+) -> Result<(), CassError> {
     unsafe {
-        let query = CString::new("INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, \
-                                  ?);");
+        let query = CString::new(
+            "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, \
+                                  ?);",
+        );
         let statement = cass_statement_new(query.unwrap().as_ptr(), 6);
 
         cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());
@@ -48,7 +54,11 @@ fn insert_into_basic(session: &mut CassSession, key: &str, basic: &mut Basic) ->
     }
 }
 
-fn select_from_basic(session: &mut CassSession, key: &str, basic: &mut Basic) -> Result<(), CassError> {
+fn select_from_basic(
+    session: &mut CassSession,
+    key: &str,
+    basic: &mut Basic,
+) -> Result<(), CassError> {
     unsafe {
         let query = "SELECT * FROM examples.basic WHERE key = ?";
         let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 1);
@@ -115,10 +125,12 @@ pub fn main() {
                     i32: 0,
                     i64: 0,
                 };
-                execute_query(session,
-                              "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
-                               'SimpleStrategy', 'replication_factor': '1' };")
-                    .unwrap();
+                execute_query(
+                    session,
+                    "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
+                               'SimpleStrategy', 'replication_factor': '1' };",
+                )
+                .unwrap();
                 execute_query(session,
                               "CREATE TABLE IF NOT EXISTS examples.basic (key text, bln boolean, flt float, dbl \
                                double, i32 int, i64 bigint, PRIMARY KEY (key));")
@@ -138,7 +150,7 @@ pub fn main() {
 
                 let close_future = cass_session_close(session);
 
-               cass_future_wait(close_future);
+                cass_future_wait(close_future);
                 cass_future_free(close_future);
             }
             err => println!("Error: {:?}", err),

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -4,9 +4,9 @@
 extern crate cassandra_cpp_sys;
 
 mod examples_util;
+use cassandra_cpp_sys::*;
 use examples_util::*;
 use std::ffi::CString;
-use cassandra_cpp_sys::*;
 
 struct Pair {
     key: String,
@@ -35,8 +35,11 @@ fn prepare_insert_into_batch<'a>(session: &mut CassSession) -> Result<&'a CassPr
     }
 }
 
-fn insert_into_batch_with_prepared(session: &mut CassSession, prepared: &CassPrepared, pairs: Vec<Pair>)
-                                   -> Result<(), CassError> {
+fn insert_into_batch_with_prepared(
+    session: &mut CassSession,
+    prepared: &CassPrepared,
+    pairs: Vec<Pair>,
+) -> Result<(), CassError> {
     unsafe {
         let batch = cass_batch_new(CASS_BATCH_TYPE_LOGGED);
 
@@ -89,20 +92,21 @@ fn insert_into_batch_with_prepared(session: &mut CassSession, prepared: &CassPre
     }
 }
 
-
 pub fn main() {
     unsafe {
         let cluster = create_cluster();
         let session = &mut *cass_session_new();
 
-        let pairs = vec![Pair {
-                             key: "a".to_owned(),
-                             value: "1".to_owned(),
-                         },
-                         Pair {
-                             key: "b".to_owned(),
-                             value: "2".to_owned(),
-                         }];
+        let pairs = vec![
+            Pair {
+                key: "a".to_owned(),
+                value: "1".to_owned(),
+            },
+            Pair {
+                key: "b".to_owned(),
+                value: "2".to_owned(),
+            },
+        ];
 
         connect_session(session, &cluster).unwrap();
 
@@ -111,10 +115,11 @@ pub fn main() {
                        \'replication_factor\': \'3\' };")
             .unwrap();
 
-
-        execute_query(session,
-                      "CREATE TABLE IF NOT EXISTS examples.pairs (key text, value text, PRIMARY KEY (key));")
-            .unwrap();
+        execute_query(
+            session,
+            "CREATE TABLE IF NOT EXISTS examples.pairs (key text, value text, PRIMARY KEY (key));",
+        )
+        .unwrap();
 
         match prepare_insert_into_batch(session) {
             Ok(prepared) => {
@@ -130,6 +135,5 @@ pub fn main() {
 
         cass_cluster_free(cluster);
         cass_session_free(session);
-
     }
 }

--- a/examples/bind_by_name.rs
+++ b/examples/bind_by_name.rs
@@ -3,12 +3,11 @@
 extern crate cassandra_cpp_sys;
 
 mod examples_util;
+use cassandra_cpp_sys::*;
 use examples_util::*;
 use std::ffi::CString;
-use cassandra_cpp_sys::*;
 
-
-#[derive(Copy,Clone)]
+#[derive(Copy, Clone)]
 struct Basic {
     bln: cass_bool_t,
     flt: f32,
@@ -17,7 +16,10 @@ struct Basic {
     i64: i64,
 }
 
-fn prepare_query<'a>(session: &mut CassSession, query: &str) -> Result<&'a CassPrepared, CassError> {
+fn prepare_query<'a>(
+    session: &mut CassSession,
+    query: &str,
+) -> Result<&'a CassPrepared, CassError> {
     unsafe {
         let future = &mut *cass_session_prepare(session, CString::new(query).unwrap().as_ptr());
         cass_future_wait(future);
@@ -37,18 +39,44 @@ fn prepare_query<'a>(session: &mut CassSession, query: &str) -> Result<&'a CassP
     }
 }
 
-fn insert_into_basic(session: &mut CassSession, prepared: &CassPrepared, key: &str, basic: &Basic)
-                     -> Result<(), CassError> {
+fn insert_into_basic(
+    session: &mut CassSession,
+    prepared: &CassPrepared,
+    key: &str,
+    basic: &Basic,
+) -> Result<(), CassError> {
     unsafe {
         let statement = cass_prepared_bind(prepared);
-        cass_statement_bind_string_by_name(statement,
-                                           CString::new("key").unwrap().as_ptr(),
-                                           CString::new(key).unwrap().as_ptr());
-        cass_statement_bind_bool_by_name(statement, CString::new("bln").unwrap().as_ptr(), basic.bln);
-        cass_statement_bind_float_by_name(statement, CString::new("flt").unwrap().as_ptr(), basic.flt);
-        cass_statement_bind_double_by_name(statement, CString::new("dbl").unwrap().as_ptr(), basic.dbl);
-        cass_statement_bind_int32_by_name(statement, CString::new("i32").unwrap().as_ptr(), basic.i32);
-        cass_statement_bind_int64_by_name(statement, CString::new("i64").unwrap().as_ptr(), basic.i64);
+        cass_statement_bind_string_by_name(
+            statement,
+            CString::new("key").unwrap().as_ptr(),
+            CString::new(key).unwrap().as_ptr(),
+        );
+        cass_statement_bind_bool_by_name(
+            statement,
+            CString::new("bln").unwrap().as_ptr(),
+            basic.bln,
+        );
+        cass_statement_bind_float_by_name(
+            statement,
+            CString::new("flt").unwrap().as_ptr(),
+            basic.flt,
+        );
+        cass_statement_bind_double_by_name(
+            statement,
+            CString::new("dbl").unwrap().as_ptr(),
+            basic.dbl,
+        );
+        cass_statement_bind_int32_by_name(
+            statement,
+            CString::new("i32").unwrap().as_ptr(),
+            basic.i32,
+        );
+        cass_statement_bind_int64_by_name(
+            statement,
+            CString::new("i64").unwrap().as_ptr(),
+            basic.i64,
+        );
 
         let future = &mut *cass_session_execute(session, statement);
 
@@ -72,14 +100,20 @@ fn insert_into_basic(session: &mut CassSession, prepared: &CassPrepared, key: &s
     }
 }
 
-fn select_from_basic<'a>(session: &mut CassSession, prepared: &CassPrepared, key: &str, basic: Basic)
-                         -> Result<Basic, CassError> {
+fn select_from_basic<'a>(
+    session: &mut CassSession,
+    prepared: &CassPrepared,
+    key: &str,
+    basic: Basic,
+) -> Result<Basic, CassError> {
     unsafe {
         let statement = cass_prepared_bind(prepared);
         cass_prepared_free(prepared);
-        cass_statement_bind_string_by_name(statement,
-                                           CString::new("key").unwrap().as_ptr(),
-                                           CString::new(key).unwrap().as_ptr());
+        cass_statement_bind_string_by_name(
+            statement,
+            CString::new("key").unwrap().as_ptr(),
+            CString::new(key).unwrap().as_ptr(),
+        );
 
         let future = &mut *cass_session_execute(session, statement);
         cass_future_wait(future);
@@ -95,16 +129,26 @@ fn select_from_basic<'a>(session: &mut CassSession, prepared: &CassPrepared, key
                 if cass_iterator_next(iterator) == cass_true {
                     let row = cass_iterator_get_row(iterator);
 
-                    cass_value_get_bool(cass_row_get_column_by_name(row, CString::new("bln").unwrap().as_ptr()),
-                                        &mut output.bln);
-                    cass_value_get_double(cass_row_get_column_by_name(row, CString::new("dbl").unwrap().as_ptr()),
-                                          &mut output.dbl);
-                    cass_value_get_float(cass_row_get_column_by_name(row, CString::new("flt").unwrap().as_ptr()),
-                                         &mut output.flt);
-                    cass_value_get_int32(cass_row_get_column_by_name(row, CString::new("i32").unwrap().as_ptr()),
-                                         &mut output.i32);
-                    cass_value_get_int64(cass_row_get_column_by_name(row, CString::new("i64").unwrap().as_ptr()),
-                                         &mut output.i64);
+                    cass_value_get_bool(
+                        cass_row_get_column_by_name(row, CString::new("bln").unwrap().as_ptr()),
+                        &mut output.bln,
+                    );
+                    cass_value_get_double(
+                        cass_row_get_column_by_name(row, CString::new("dbl").unwrap().as_ptr()),
+                        &mut output.dbl,
+                    );
+                    cass_value_get_float(
+                        cass_row_get_column_by_name(row, CString::new("flt").unwrap().as_ptr()),
+                        &mut output.flt,
+                    );
+                    cass_value_get_int32(
+                        cass_row_get_column_by_name(row, CString::new("i32").unwrap().as_ptr()),
+                        &mut output.i32,
+                    );
+                    cass_value_get_int64(
+                        cass_row_get_column_by_name(row, CString::new("i64").unwrap().as_ptr()),
+                        &mut output.i64,
+                    );
                 }
                 cass_iterator_free(iterator);
                 cass_result_free(result);
@@ -136,15 +180,18 @@ fn main() {
             i64: 2,
         };
 
-        let insert_query = "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);";
+        let insert_query =
+            "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);";
         let select_query = "SELECT * FROM examples.basic WHERE key = ?";
 
         match connect_session(session, cluster) {
             Ok(()) => {
-                execute_query(session,
-                              "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { \'class\': \
-                               \'SimpleStrategy\', \'replication_factor\': \'1\' };")
-                    .unwrap();
+                execute_query(
+                    session,
+                    "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { \'class\': \
+                               \'SimpleStrategy\', \'replication_factor\': \'1\' };",
+                )
+                .unwrap();
 
                 execute_query(session,
                               "CREATE TABLE IF NOT EXISTS examples.basic (key text, bln boolean, flt float, dbl \
@@ -153,12 +200,18 @@ fn main() {
 
                 match prepare_query(session, &insert_query) {
                     Ok(insert_prepared) => {
-                        insert_into_basic(session, insert_prepared, "prepared_test", &input).unwrap();
+                        insert_into_basic(session, insert_prepared, "prepared_test", &input)
+                            .unwrap();
                         cass_prepared_free(insert_prepared);
                         match prepare_query(session, &select_query) {
                             Ok(select_prepared) => {
-                                let output = select_from_basic(session, select_prepared, "prepared_test", input)
-                                    .unwrap();
+                                let output = select_from_basic(
+                                    session,
+                                    select_prepared,
+                                    "prepared_test",
+                                    input,
+                                )
+                                .unwrap();
 
                                 assert!(input.bln.clone() == output.bln);
                                 assert!(input.flt == output.flt);
@@ -181,6 +234,5 @@ fn main() {
         cass_future_free(close_future);
         cass_cluster_free(&mut *cluster);
         cass_session_free(session);
-
     }
 }

--- a/examples/collections.rs
+++ b/examples/collections.rs
@@ -6,12 +6,15 @@ extern crate cassandra_cpp_sys;
 mod examples_util;
 use examples_util::*;
 
-use std::mem;
-use std::ffi::CString;
 use cassandra_cpp_sys::*;
+use std::ffi::CString;
+use std::mem;
 
-
-fn insert_into_collections(session: &mut CassSession, key: &str, items: Vec<&str>) -> Result<(), CassError> {
+fn insert_into_collections(
+    session: &mut CassSession,
+    key: &str,
+    items: Vec<&str>,
+) -> Result<(), CassError> {
     unsafe {
         let query = "INSERT INTO examples.collections (key, items) VALUES (?, ?);";
 
@@ -65,9 +68,11 @@ fn select_from_collections(session: &mut CassSession, key: &str) -> Result<(), C
                     while cass_iterator_next(items_iterator) == cass_true {
                         let mut item = mem::zeroed();
                         let mut item_length = mem::zeroed();
-                        cass_value_get_string(cass_iterator_get_value(items_iterator),
-                                              &mut item,
-                                              &mut item_length);
+                        cass_value_get_string(
+                            cass_iterator_get_value(items_iterator),
+                            &mut item,
+                            &mut item_length,
+                        );
                         println!("item: {:?}", raw2utf8(item, item_length));
                     }
                     cass_iterator_free(items_iterator);
@@ -107,7 +112,6 @@ fn main() {
         execute_query(session,
                       "CREATE TABLE IF NOT EXISTS examples.collections (key text, items set<text>, PRIMARY KEY (key))")
             .unwrap();
-
 
         insert_into_collections(session, "test", items).unwrap();
         select_from_collections(session, "test").unwrap();

--- a/examples/examples_util/mod.rs
+++ b/examples/examples_util/mod.rs
@@ -2,8 +2,8 @@
 
 use cassandra_cpp_sys::*;
 
-use std::mem;
 use std::ffi::CString;
+use std::mem;
 
 pub fn print_error(future: &mut CassFuture) {
     unsafe {

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -8,9 +8,9 @@ mod examples_util;
 use examples_util::*;
 use std::os::raw;
 
-use std::ptr;
 use std::env;
 use std::ffi::CStr;
+use std::ptr;
 
 use cassandra_cpp_sys::*;
 
@@ -18,14 +18,14 @@ unsafe extern "C" fn on_log(message: *const CassLogMessage, data: *mut raw::c_vo
     let _ = data;
     let message = &*message;
     info!(target: "cass_log", "{:?}.{:?} [{:?}] ({:?}:{:?}:{:?}) {:?}",
-            message.time_ms / 1000,
-            message.time_ms % 1000,
-            message.severity,
-            message.file,
-            message.line,
-            message.function,
-            CStr::from_ptr(message.message[..].as_ptr())
-        );
+        message.time_ms / 1000,
+        message.time_ms % 1000,
+        message.severity,
+        message.file,
+        message.line,
+        message.function,
+        CStr::from_ptr(message.message[..].as_ptr())
+    );
 }
 
 fn main() {
@@ -47,6 +47,5 @@ fn main() {
 
         cass_cluster_free(cluster);
         cass_session_free(session);
-
     }
 }

--- a/examples/maps.rs
+++ b/examples/maps.rs
@@ -5,8 +5,8 @@ extern crate cassandra_cpp_sys;
 
 mod examples_util;
 use examples_util::*;
-use std::mem;
 use std::ffi::CString;
+use std::mem;
 
 use cassandra_cpp_sys::*;
 
@@ -15,7 +15,11 @@ struct Pair {
     value: i32,
 }
 
-fn insert_into_maps(session: &mut CassSession, key: &str, items: Vec<Pair>) -> Result<(), CassError> {
+fn insert_into_maps(
+    session: &mut CassSession,
+    key: &str,
+    items: Vec<Pair>,
+) -> Result<(), CassError> {
     unsafe {
         let query = "INSERT INTO examples.maps (key, items) VALUES (?, ?);";
         let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 2);
@@ -71,14 +75,18 @@ fn select_from_maps(session: &mut CassSession, key: &str) -> Result<(), CassErro
                         let mut item_key = mem::zeroed();
                         let mut item_key_length = mem::zeroed();
                         let mut value = mem::zeroed();
-                        cass_value_get_string(cass_iterator_get_map_key(iterator),
-                                              &mut item_key,
-                                              &mut item_key_length);
+                        cass_value_get_string(
+                            cass_iterator_get_map_key(iterator),
+                            &mut item_key,
+                            &mut item_key_length,
+                        );
                         cass_value_get_int32(cass_iterator_get_map_value(iterator), &mut value);
 
-                        println!("item: '{:?}' : {:?}",
-                                 raw2utf8(item_key, item_key_length),
-                                 value);
+                        println!(
+                            "item: '{:?}' : {:?}",
+                            raw2utf8(item_key, item_key_length),
+                            value
+                        );
                     }
                     cass_iterator_free(iterator);
                     cass_result_free(result);
@@ -95,22 +103,24 @@ fn select_from_maps(session: &mut CassSession, key: &str) -> Result<(), CassErro
 
 fn main() {
     unsafe {
-        let items = vec![Pair {
-                             key: "apple".to_owned(),
-                             value: 1,
-                         },
-                         Pair {
-                             key: "orange".to_owned(),
-                             value: 2,
-                         },
-                         Pair {
-                             key: "banana".to_owned(),
-                             value: 3,
-                         },
-                         Pair {
-                             key: "mango".to_owned(),
-                             value: 4,
-                         }];
+        let items = vec![
+            Pair {
+                key: "apple".to_owned(),
+                value: 1,
+            },
+            Pair {
+                key: "orange".to_owned(),
+                value: 2,
+            },
+            Pair {
+                key: "banana".to_owned(),
+                value: 3,
+            },
+            Pair {
+                key: "mango".to_owned(),
+                value: 4,
+            },
+        ];
 
         let cluster = create_cluster();
         let session = &mut *cass_session_new();
@@ -125,7 +135,6 @@ fn main() {
         execute_query(session,
                       "CREATE TABLE IF NOT EXISTS examples.maps (key text, items map<text, int>, PRIMARY KEY (key))")
             .unwrap();
-
 
         insert_into_maps(session, "test", items).unwrap();
         //        select_from_maps(session, "test").unwrap();

--- a/examples/named_parameters.rs
+++ b/examples/named_parameters.rs
@@ -3,9 +3,9 @@
 
 extern crate cassandra_cpp_sys;
 
-use std::mem;
-use std::ffi::CString;
 use cassandra_cpp_sys::*;
+use std::ffi::CString;
+use std::mem;
 
 #[derive(Clone)]
 struct Basic {
@@ -66,9 +66,11 @@ fn execute_query(session: &mut CassSession, query: &str) -> Result<(), CassError
 
 fn insert_into_basic(session: &mut CassSession, key: &str, basic: &Basic) -> Result<(), CassError> {
     unsafe {
-        let query = CString::new("INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (:k, :b, :f, :d, \
-                                  :i32, :i64);")
-            .unwrap();
+        let query = CString::new(
+            "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (:k, :b, :f, :d, \
+                                  :i32, :i64);",
+        )
+        .unwrap();
         let key = CString::new(key).unwrap();
         let statement = &mut *cass_statement_new(query.as_ptr(), 6);
         let k = CString::new("k").unwrap().as_ptr();
@@ -112,15 +114,16 @@ fn select_from_basic(session: &mut CassSession, key: &str) -> Result<Basic, Cass
 
         let statement = &mut *cass_statement_new(query.as_ptr(), 1);
 
-        cass_statement_bind_string_by_name(statement,
-                                           CString::new("key").unwrap().as_ptr(),
-                                           key.as_ptr());
+        cass_statement_bind_string_by_name(
+            statement,
+            CString::new("key").unwrap().as_ptr(),
+            key.as_ptr(),
+        );
 
         let future = &mut *cass_session_execute(session, statement);
         cass_future_wait(future);
 
         let rc = cass_future_error_code(future);
-
 
         match rc {
             CASS_OK => {
@@ -130,22 +133,31 @@ fn select_from_basic(session: &mut CassSession, key: &str) -> Result<Basic, Cass
                 if cass_iterator_next(iterator) == cass_true {
                     let row = &*cass_iterator_get_row(iterator);
 
-                    cass_value_get_bool(cass_row_get_column_by_name(row, CString::new("BLN").unwrap().as_ptr()),
-                                        &mut output.bln);
-                    cass_value_get_double(cass_row_get_column_by_name(row, CString::new("dbl").unwrap().as_ptr()),
-                                          &mut output.dbl);
-                    cass_value_get_float(cass_row_get_column_by_name(row, CString::new("flt").unwrap().as_ptr()),
-                                         &mut output.flt);
-                    cass_value_get_int32(cass_row_get_column_by_name(row, CString::new("\"i32\"").unwrap().as_ptr()),
-                                         &mut output.i32);
-                    cass_value_get_int64(cass_row_get_column_by_name(row, CString::new("i64").unwrap().as_ptr()),
-                                         &mut output.i64);
+                    cass_value_get_bool(
+                        cass_row_get_column_by_name(row, CString::new("BLN").unwrap().as_ptr()),
+                        &mut output.bln,
+                    );
+                    cass_value_get_double(
+                        cass_row_get_column_by_name(row, CString::new("dbl").unwrap().as_ptr()),
+                        &mut output.dbl,
+                    );
+                    cass_value_get_float(
+                        cass_row_get_column_by_name(row, CString::new("flt").unwrap().as_ptr()),
+                        &mut output.flt,
+                    );
+                    cass_value_get_int32(
+                        cass_row_get_column_by_name(row, CString::new("\"i32\"").unwrap().as_ptr()),
+                        &mut output.i32,
+                    );
+                    cass_value_get_int64(
+                        cass_row_get_column_by_name(row, CString::new("i64").unwrap().as_ptr()),
+                        &mut output.i64,
+                    );
                     cass_result_free(result);
                     cass_iterator_free(iterator);
                 }
             }
             rc => println!("{:?}", rc),
-
         }
 
         cass_future_free(future);
@@ -175,19 +187,15 @@ fn main() {
             }
         };
 
-
-
         execute_query(session,
                       "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': 'SimpleStrategy', \
                        'replication_factor': '3' };")
             .unwrap();
 
-
         execute_query(session,
                       "CREATE TABLE IF NOT EXISTS examples.basic (key text, bln boolean, flt float, dbl double,i32 \
                        int, i64 bigint, PRIMARY KEY (key));")
             .unwrap();
-
 
         insert_into_basic(session, "named_parameters", &input).unwrap();
         let output = select_from_basic(session, "named_parameters").unwrap();
@@ -204,6 +212,5 @@ fn main() {
 
         cass_cluster_free(cluster);
         cass_session_free(session);
-
     }
 }

--- a/examples/paging.rs
+++ b/examples/paging.rs
@@ -7,8 +7,8 @@ use std::ffi::CString;
 mod examples_util;
 use examples_util::*;
 
-use std::mem;
 use std::ffi::CStr;
+use std::mem;
 
 use cassandra_cpp_sys::*;
 
@@ -79,10 +79,16 @@ fn select_from_paging(session: &mut CassSession) {
                         cass_value_get_uuid(cass_row_get_column(row, 0), &mut key);
                         cass_uuid_string(key, key_str[..].as_mut_ptr());
 
-                        cass_value_get_string(cass_row_get_column(row, 1), &mut value, &mut value_length);
-                        println!("key: {:?} value: {:?}",
-                                 CStr::from_ptr(key_str[..].as_ptr()),
-                                 raw2utf8(value, value_length).unwrap());
+                        cass_value_get_string(
+                            cass_row_get_column(row, 1),
+                            &mut value,
+                            &mut value_length,
+                        );
+                        println!(
+                            "key: {:?} value: {:?}",
+                            CStr::from_ptr(key_str[..].as_ptr()),
+                            raw2utf8(value, value_length).unwrap()
+                        );
                     }
                     match cass_result_has_more_pages(result) == cass_true {
                         true => {
@@ -115,7 +121,6 @@ fn main() {
                        'replication_factor': '3' };")
             .unwrap();
 
-
         execute_query(session,
                       "CREATE TABLE IF NOT EXISTS examples.paging (key timeuuid, value text, PRIMARY KEY (key));")
             .unwrap();
@@ -132,6 +137,5 @@ fn main() {
         cass_uuid_gen_free(uuid_gen);
         cass_cluster_free(cluster);
         cass_session_free(session);
-
     }
 }

--- a/examples/prepared.rs
+++ b/examples/prepared.rs
@@ -21,7 +21,8 @@ struct Basic {
 
 fn insert_into_basic(session: &mut CassSession, key: &str, basic: &Basic) -> Result<(), CassError> {
     unsafe {
-        let query = "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);";
+        let query =
+            "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);";
         let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 6);
 
         cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());
@@ -70,8 +71,12 @@ fn prepare_select_from_basic(session: &mut CassSession) -> Result<&CassPrepared,
     }
 }
 
-fn select_from_basic(session: &mut CassSession, prepared: &CassPrepared, key: &str, basic: &mut Basic)
-                     -> Result<(), CassError> {
+fn select_from_basic(
+    session: &mut CassSession,
+    prepared: &CassPrepared,
+    key: &str,
+    basic: &mut Basic,
+) -> Result<(), CassError> {
     unsafe {
         let statement = cass_prepared_bind(prepared);
         cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());

--- a/examples/schema_meta.rs
+++ b/examples/schema_meta.rs
@@ -35,11 +35,13 @@ unsafe fn print_schema_value(value: &CassValue) {
 
         CASS_VALUE_TYPE_BOOLEAN => {
             cass_value_get_bool(value, &mut b);
-            println!("{}",
-                     match b {
-                         cass_true => "true",
-                         cass_false => "false",
-                     });
+            println!(
+                "{}",
+                match b {
+                    cass_true => "true",
+                    cass_false => "false",
+                }
+            );
         }
 
         CASS_VALUE_TYPE_DOUBLE => {
@@ -47,9 +49,7 @@ unsafe fn print_schema_value(value: &CassValue) {
             println!("{}", d);
         }
 
-        CASS_VALUE_TYPE_TEXT |
-        CASS_VALUE_TYPE_ASCII |
-        CASS_VALUE_TYPE_VARCHAR => {
+        CASS_VALUE_TYPE_TEXT | CASS_VALUE_TYPE_ASCII | CASS_VALUE_TYPE_VARCHAR => {
             let mut s = mem::zeroed();
             let mut s_size = mem::zeroed();
             cass_value_get_string(value, &mut s, &mut s_size);
@@ -69,12 +69,10 @@ unsafe fn print_schema_value(value: &CassValue) {
         CASS_VALUE_TYPE_MAP => {
             print_schema_map(value);
         }
-        _ => {
-            match cass_value_is_null(value) {
-                cass_true => println!("<unhandled type>: {:?}", cass_value_type(value)),
-                cass_false => println!("null"),
-            }
-        }
+        _ => match cass_value_is_null(value) {
+            cass_true => println!("<unhandled type>: {:?}", cass_value_type(value)),
+            cass_false => println!("null"),
+        },
     }
 }
 
@@ -113,13 +111,16 @@ unsafe fn print_schema_map(value: &CassValue) {
 
 unsafe fn print_keyspace(session: &mut CassSession, keyspace: &str) {
     let schema_meta = cass_session_get_schema_meta(session);
-    let keyspace_meta = cass_schema_meta_keyspace_by_name(schema_meta, CString::new(keyspace).unwrap().as_ptr());
+    let keyspace_meta =
+        cass_schema_meta_keyspace_by_name(schema_meta, CString::new(keyspace).unwrap().as_ptr());
 
     if !keyspace_meta.is_null() {
         print_keyspace_meta(&*keyspace_meta, 0);
     } else {
-        println!("Unable to find {} keyspace in the schema metadata",
-                 keyspace);
+        println!(
+            "Unable to find {} keyspace in the schema metadata",
+            keyspace
+        );
     }
     cass_schema_meta_free(schema_meta);
 }
@@ -142,7 +143,6 @@ unsafe fn print_meta_field(iterator: *const CassIterator, indent: u32) {
     print_schema_value(&*value);
     println!("");
 }
-
 
 unsafe fn print_keyspace_meta(meta: *const CassKeyspaceMeta, indent: u32) {
     //  const char* name;
@@ -168,11 +168,9 @@ unsafe fn print_keyspace_meta(meta: *const CassKeyspaceMeta, indent: u32) {
     cass_iterator_free(iterator);
 }
 
-
 unsafe fn print_table_meta(meta: *const CassTableMeta, indent: u32) {
     let mut name = mem::zeroed();
     let mut name_length = mem::zeroed();
-
 
     print_indent(indent);
     cass_table_meta_name(meta, &mut name, &mut name_length);
@@ -191,7 +189,6 @@ unsafe fn print_table_meta(meta: *const CassTableMeta, indent: u32) {
 }
 
 unsafe fn print_column_meta(meta: *const CassColumnMeta, indent: u32) {
-
     let mut name = mem::zeroed();
     let mut name_length = mem::zeroed();
 
@@ -202,22 +199,24 @@ unsafe fn print_column_meta(meta: *const CassColumnMeta, indent: u32) {
     println!("");
 }
 
-
-
 unsafe fn print_table(session: &mut CassSession, keyspace: &str, table: &str) {
     let schema_meta = cass_session_get_schema_meta(session);
-    let keyspace_meta = cass_schema_meta_keyspace_by_name(schema_meta, CString::new(keyspace).unwrap().as_ptr());
+    let keyspace_meta =
+        cass_schema_meta_keyspace_by_name(schema_meta, CString::new(keyspace).unwrap().as_ptr());
 
     if !keyspace_meta.is_null() {
-        let table_meta = cass_keyspace_meta_table_by_name(keyspace_meta, CString::new(table).unwrap().as_ptr());
+        let table_meta =
+            cass_keyspace_meta_table_by_name(keyspace_meta, CString::new(table).unwrap().as_ptr());
         if !table_meta.is_null() {
             print_table_meta(&*table_meta, 0);
         } else {
             println!("Unable to find {} table in the schemaname metadata", table);
         }
     } else {
-        println!("Unable to find {} keyspace in the schema metadata",
-                 keyspace);
+        println!(
+            "Unable to find {} keyspace in the schema metadata",
+            keyspace
+        );
     }
     cass_schema_meta_free(schema_meta);
 }
@@ -232,11 +231,12 @@ pub fn main() {
 
         match cass_future_error_code(connect_future) {
             CASS_OK => {
-
-                execute_query(&mut *session,
-                              "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
-                               'SimpleStrategy', 'replication_factor': '3' };")
-                    .unwrap();
+                execute_query(
+                    &mut *session,
+                    "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
+                               'SimpleStrategy', 'replication_factor': '3' };",
+                )
+                .unwrap();
 
                 print_keyspace(&mut *session, "examples");
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,8 +3,8 @@
 
 extern crate cassandra_cpp_sys;
 
-use std::mem;
 use std::ffi::CString;
+use std::mem;
 
 use cassandra_cpp_sys::*;
 
@@ -36,14 +36,22 @@ fn main() {
 
                         while cass_iterator_next(rows) == cass_true {
                             let row = cass_iterator_get_row(rows);
-                            let value = cass_row_get_column_by_name(row,
-                                                                    CString::new("keyspace_name").unwrap().as_ptr());
+                            let value = cass_row_get_column_by_name(
+                                row,
+                                CString::new("keyspace_name").unwrap().as_ptr(),
+                            );
 
                             let mut keyspace_name = mem::zeroed();
                             let mut keyspace_name_length = mem::zeroed();
-                            cass_value_get_string(value, &mut keyspace_name, &mut keyspace_name_length);
-                            println!("keyspace_name: {:?}",
-                                     raw2utf8(keyspace_name, keyspace_name_length).unwrap());
+                            cass_value_get_string(
+                                value,
+                                &mut keyspace_name,
+                                &mut keyspace_name_length,
+                            );
+                            println!(
+                                "keyspace_name: {:?}",
+                                raw2utf8(keyspace_name, keyspace_name_length).unwrap()
+                            );
                         }
 
                         cass_result_free(result);
@@ -54,8 +62,10 @@ fn main() {
                         let mut message = mem::zeroed();
                         let mut message_length = mem::zeroed();
                         cass_future_error_message(result_future, &mut message, &mut message_length);
-                        println!("Unable to run query: {:?}",
-                                 raw2utf8(message, message_length));
+                        println!(
+                            "Unable to run query: {:?}",
+                            raw2utf8(message, message_length)
+                        );
                     }
                 }
 
@@ -75,11 +85,5 @@ fn main() {
                 println!("Unable to connect: {:?}", raw2utf8(message, message_length));
             }
         };
-
-
-
     };
-
-
-
 }

--- a/examples/ssl.rs
+++ b/examples/ssl.rs
@@ -3,12 +3,12 @@
 
 extern crate cassandra_cpp_sys;
 
-use std::mem;
-use std::io::Result as IoResult;
-use std::io::Read;
-use std::fs::File;
 use cassandra_cpp_sys::*;
 use std::ffi::CString;
+use std::fs::File;
+use std::io::Read;
+use std::io::Result as IoResult;
+use std::mem;
 
 fn load_trusted_cert_file(file: &str, ssl: &mut CassSsl) -> IoResult<()> {
     unsafe {
@@ -49,8 +49,10 @@ fn main() {
         match load_trusted_cert_file("cert.pem", &mut *ssl) {
             Ok(_) => {}
             rc => {
-                println!("Failed to load certificate disabling peer verification: {:?}",
-                         rc);
+                println!(
+                    "Failed to load certificate disabling peer verification: {:?}",
+                    rc
+                );
                 cass_ssl_set_verify_flags(ssl, CASS_SSL_VERIFY_NONE as i32);
             }
         }
@@ -61,7 +63,6 @@ fn main() {
 
         match cass_future_error_code(connect_future) {
             CASS_OK => {
-
                 // Build statement and execute query
                 let query = "SELECT keyspace_name FROM system.schema_keyspaces;";
                 let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 0);
@@ -76,14 +77,22 @@ fn main() {
 
                         while cass_iterator_next(rows) == cass_true {
                             let row = cass_iterator_get_row(rows);
-                            let value = cass_row_get_column_by_name(row,
-                                                                    CString::new("keyspace_name").unwrap().as_ptr());
+                            let value = cass_row_get_column_by_name(
+                                row,
+                                CString::new("keyspace_name").unwrap().as_ptr(),
+                            );
 
                             let mut keyspace_name = mem::zeroed();
                             let mut keyspace_name_length = mem::zeroed();
-                            cass_value_get_string(value, &mut keyspace_name, &mut keyspace_name_length);
-                            println!("keyspace_name: {:?}",
-                                     raw2utf8(keyspace_name, keyspace_name_length));
+                            cass_value_get_string(
+                                value,
+                                &mut keyspace_name,
+                                &mut keyspace_name_length,
+                            );
+                            println!(
+                                "keyspace_name: {:?}",
+                                raw2utf8(keyspace_name, keyspace_name_length)
+                            );
                         }
 
                         cass_result_free(result);
@@ -94,8 +103,10 @@ fn main() {
                         let mut message = mem::zeroed();
                         let mut message_length = mem::zeroed();
                         cass_future_error_message(result_future, &mut message, &mut message_length);
-                        println!("Unable to run query: {:?}",
-                                 raw2utf8(message, message_length));
+                        println!(
+                            "Unable to run query: {:?}",
+                            raw2utf8(message, message_length)
+                        );
                     }
                 }
 
@@ -112,8 +123,10 @@ fn main() {
                 let mut message = mem::zeroed();
                 let mut message_length = mem::zeroed();
                 cass_future_error_message(connect_future, &mut message, &mut message_length);
-                println!("Unable to connect: : {:?}",
-                         raw2utf8(message, message_length));
+                println!(
+                    "Unable to connect: : {:?}",
+                    raw2utf8(message, message_length)
+                );
             }
         }
         cass_future_free(connect_future);

--- a/examples/tuple.rs
+++ b/examples/tuple.rs
@@ -7,11 +7,13 @@ mod examples_util;
 use examples_util::*;
 use std::ffi::CString;
 
-use std::mem;
 use cassandra_cpp_sys::*;
+use std::mem;
 
-
-fn insert_into_tuple(session: &mut CassSession, uuid_gen: &mut CassUuidGen) -> Result<(), CassError> {
+fn insert_into_tuple(
+    session: &mut CassSession,
+    uuid_gen: &mut CassUuidGen,
+) -> Result<(), CassError> {
     unsafe {
         let mut id = mem::zeroed();
         let mut id_str: [i8; 37] = mem::zeroed();
@@ -65,8 +67,10 @@ fn select_from_tuple(session: &mut CassSession) -> Result<(), CassError> {
                     let mut id = mem::zeroed();
                     let mut id_str = mem::zeroed();
                     let row = cass_iterator_get_row(rows);
-                    let id_value = cass_row_get_column_by_name(row, CString::new("id").unwrap().as_ptr());
-                    let item_value = cass_row_get_column_by_name(row, CString::new("item").unwrap().as_ptr());
+                    let id_value =
+                        cass_row_get_column_by_name(row, CString::new("id").unwrap().as_ptr());
+                    let item_value =
+                        cass_row_get_column_by_name(row, CString::new("item").unwrap().as_ptr());
                     let item = cass_iterator_from_tuple(item_value);
 
                     cass_value_get_uuid(id_value, &mut id);
@@ -78,24 +82,22 @@ fn select_from_tuple(session: &mut CassSession) -> Result<(), CassError> {
                         let value = cass_iterator_get_value(item);
 
                         match cass_value_is_null(value) {
-                            cass_true => {
-                                match cass_value_type(value) {
-                                    CASS_VALUE_TYPE_VARCHAR => {
-                                        let mut text = mem::zeroed();
-                                        let mut text_length = mem::zeroed();
-                                        cass_value_get_string(value, &mut text, &mut text_length);
-                                        print!("{:?} ", raw2utf8(text, text_length).unwrap());
-                                    }
-                                    CASS_VALUE_TYPE_BIGINT => {
-                                        let mut i = mem::zeroed();
-                                        cass_value_get_int64(value, &mut i);
-                                        print!("{:?} ", i);
-                                    }
-                                    other_type => {
-                                        print!("<invalid type {:?}> ", other_type);
-                                    }
+                            cass_true => match cass_value_type(value) {
+                                CASS_VALUE_TYPE_VARCHAR => {
+                                    let mut text = mem::zeroed();
+                                    let mut text_length = mem::zeroed();
+                                    cass_value_get_string(value, &mut text, &mut text_length);
+                                    print!("{:?} ", raw2utf8(text, text_length).unwrap());
                                 }
-                            }
+                                CASS_VALUE_TYPE_BIGINT => {
+                                    let mut i = mem::zeroed();
+                                    cass_value_get_int64(value, &mut i);
+                                    print!("{:?} ", i);
+                                }
+                                other_type => {
+                                    print!("<invalid type {:?}> ", other_type);
+                                }
+                            },
                             cass_false => print!("<null> "),
                         }
                     }
@@ -126,10 +128,12 @@ fn main() {
 
         match connect_session(session, cluster) {
             Ok(()) => {
-                execute_query(session,
-                              "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
-                               'SimpleStrategy', 'replication_factor': '3' }")
-                    .unwrap();
+                execute_query(
+                    session,
+                    "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
+                               'SimpleStrategy', 'replication_factor': '3' }",
+                )
+                .unwrap();
                 execute_query(session,
                               "CREATE TABLE IF NOT EXISTS examples.tuples (id timeuuid, item frozen<tuple<text, \
                                bigint>>, PRIMARY KEY(id))")

--- a/examples/udt.rs
+++ b/examples/udt.rs
@@ -4,15 +4,18 @@
 extern crate cassandra_cpp_sys;
 
 mod examples_util;
+use cassandra_cpp_sys::*;
 use examples_util::*;
 use std::ffi::CString;
 use std::mem;
-use cassandra_cpp_sys::*;
 
 const CASS_UUID_STRING_LENGTH: usize = 37;
 
-fn insert_into_udt(session: &mut CassSession, schema_meta: &CassSchemaMeta, uuid_gen: &mut CassUuidGen)
-                   -> Result<(), CassError> {
+fn insert_into_udt(
+    session: &mut CassSession,
+    schema_meta: &CassSchemaMeta,
+    uuid_gen: &mut CassUuidGen,
+) -> Result<(), CassError> {
     unsafe {
         let mut id_str: [i8; CASS_UUID_STRING_LENGTH] = [0; CASS_UUID_STRING_LENGTH];
 
@@ -23,13 +26,20 @@ fn insert_into_udt(session: &mut CassSession, schema_meta: &CassSchemaMeta, uuid
         cass_uuid_gen_time(uuid_gen, &mut id);
         cass_uuid_string(id, id_str[..].as_mut_ptr());
 
-        let keyspace_meta = cass_schema_meta_keyspace_by_name(schema_meta, CString::new("examples").unwrap().as_ptr());
+        let keyspace_meta = cass_schema_meta_keyspace_by_name(
+            schema_meta,
+            CString::new("examples").unwrap().as_ptr(),
+        );
 
-        let udt_address = cass_keyspace_meta_user_type_by_name(keyspace_meta,
-                                                               CString::new("address").unwrap().as_ptr());
+        let udt_address = cass_keyspace_meta_user_type_by_name(
+            keyspace_meta,
+            CString::new("address").unwrap().as_ptr(),
+        );
 
-        let udt_phone = cass_keyspace_meta_user_type_by_name(keyspace_meta,
-                                                             CString::new("phone_numbers").unwrap().as_ptr());
+        let udt_phone = cass_keyspace_meta_user_type_by_name(
+            keyspace_meta,
+            CString::new("phone_numbers").unwrap().as_ptr(),
+        );
 
         match (udt_address.is_null(), udt_phone.is_null()) {
             (_, true) => panic!("phone is null"),
@@ -40,26 +50,40 @@ fn insert_into_udt(session: &mut CassSession, schema_meta: &CassSchemaMeta, uuid
 
                 for i in 0..2 {
                     let phone_numbers = cass_user_type_new_from_data_type(udt_phone);
-                    cass_user_type_set_int32_by_name(phone_numbers,
-                                                     CString::new("phone1").unwrap().as_ptr(),
-                                                     i + 1);
-                    cass_user_type_set_int32_by_name(phone_numbers,
-                                                     CString::new("phone2").unwrap().as_ptr(),
-                                                     i + 2);
+                    cass_user_type_set_int32_by_name(
+                        phone_numbers,
+                        CString::new("phone1").unwrap().as_ptr(),
+                        i + 1,
+                    );
+                    cass_user_type_set_int32_by_name(
+                        phone_numbers,
+                        CString::new("phone2").unwrap().as_ptr(),
+                        i + 2,
+                    );
                     cass_collection_append_user_type(phone, phone_numbers);
                     cass_user_type_free(phone_numbers);
                 }
 
-                cass_user_type_set_string_by_name(address,
-                                                  CString::new("street").unwrap().as_ptr(),
-                                                  id_str[..].as_mut_ptr());
-                cass_user_type_set_string_by_name(address,
-                                                  CString::new("city").unwrap().as_ptr(),
-                                                  id_str[..].as_mut_ptr());
-                cass_user_type_set_int32_by_name(address,
-                                                 CString::new("zip").unwrap().as_ptr(),
-                                                 id.time_and_version as i32);
-                cass_user_type_set_collection_by_name(address, CString::new("phone").unwrap().as_ptr(), phone);
+                cass_user_type_set_string_by_name(
+                    address,
+                    CString::new("street").unwrap().as_ptr(),
+                    id_str[..].as_mut_ptr(),
+                );
+                cass_user_type_set_string_by_name(
+                    address,
+                    CString::new("city").unwrap().as_ptr(),
+                    id_str[..].as_mut_ptr(),
+                );
+                cass_user_type_set_int32_by_name(
+                    address,
+                    CString::new("zip").unwrap().as_ptr(),
+                    id.time_and_version as i32,
+                );
+                cass_user_type_set_collection_by_name(
+                    address,
+                    CString::new("phone").unwrap().as_ptr(),
+                    phone,
+                );
 
                 cass_statement_bind_uuid(statement, 0, id);
                 cass_statement_bind_user_type(statement, 1, address);
@@ -86,7 +110,6 @@ fn insert_into_udt(session: &mut CassSession, schema_meta: &CassSchemaMeta, uuid
 
 fn select_from_udt(session: &mut CassSession) -> Result<(), CassError> {
     unsafe {
-
         let query = "SELECT * FROM examples.udt";
 
         let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 0);
@@ -102,8 +125,10 @@ fn select_from_udt(session: &mut CassSession) -> Result<(), CassError> {
                 while cass_iterator_next(rows) == cass_true {
                     let mut id_str: [i8; CASS_UUID_STRING_LENGTH] = [0; CASS_UUID_STRING_LENGTH];
                     let row = cass_iterator_get_row(rows);
-                    let id_value = cass_row_get_column_by_name(row, CString::new("id").unwrap().as_ptr());
-                    let address_value = cass_row_get_column_by_name(row, CString::new("address").unwrap().as_ptr());
+                    let id_value =
+                        cass_row_get_column_by_name(row, CString::new("id").unwrap().as_ptr());
+                    let address_value =
+                        cass_row_get_column_by_name(row, CString::new("address").unwrap().as_ptr());
                     let fields = cass_iterator_fields_from_user_type(address_value);
                     let mut id = mem::zeroed();
                     cass_value_get_uuid(id_value, &mut id);
@@ -114,45 +139,51 @@ fn select_from_udt(session: &mut CassSession) -> Result<(), CassError> {
                     while !fields.is_null() && cass_iterator_next(fields) == cass_true {
                         let mut field_name = mem::zeroed();
                         let mut field_name_length = mem::zeroed();
-                        cass_iterator_get_user_type_field_name(fields, &mut field_name, &mut field_name_length);
+                        cass_iterator_get_user_type_field_name(
+                            fields,
+                            &mut field_name,
+                            &mut field_name_length,
+                        );
                         let field_value = cass_iterator_get_user_type_field_value(fields);
                         println!("{:?} ", raw2utf8(field_name, field_name_length));
 
                         match cass_value_is_null(field_value) {
-                            cass_false => {
-                                match cass_value_type(field_value) {
-                                    CASS_VALUE_TYPE_VARCHAR => {
-                                        let mut text = mem::zeroed();
-                                        let mut text_length = mem::zeroed();
-                                        cass_value_get_string(field_value, &mut text, &mut text_length);
-                                        println!("\"{:?}\" ", raw2utf8(text, text_length));
-                                    }
-                                    CASS_VALUE_TYPE_INT => {
-                                        let mut i = mem::zeroed();
-                                        cass_value_get_int32(field_value, &mut i);
-                                        println!("{:?} ", i);
-                                    }
-                                    CASS_VALUE_TYPE_SET => {
-                                        let phone_numbers = cass_iterator_from_collection(field_value);
-                                        while cass_iterator_next(phone_numbers) == cass_true {
-                                            let phone_value = cass_iterator_get_value(phone_numbers);
-                                            let phone_fields = cass_iterator_fields_from_user_type(phone_value);
-                                            assert!(cass_value_type(phone_value) == CASS_VALUE_TYPE_UDT);
-                                            while cass_iterator_next(phone_fields) == cass_true {
-                                                let phone_number_value =
-                                                    cass_iterator_get_user_type_field_value(phone_fields);
-                                                let mut i = mem::zeroed();
-                                                cass_value_get_int32(phone_number_value, &mut i);
-                                                println!("{:?} ", i);
-                                            }
+                            cass_false => match cass_value_type(field_value) {
+                                CASS_VALUE_TYPE_VARCHAR => {
+                                    let mut text = mem::zeroed();
+                                    let mut text_length = mem::zeroed();
+                                    cass_value_get_string(field_value, &mut text, &mut text_length);
+                                    println!("\"{:?}\" ", raw2utf8(text, text_length));
+                                }
+                                CASS_VALUE_TYPE_INT => {
+                                    let mut i = mem::zeroed();
+                                    cass_value_get_int32(field_value, &mut i);
+                                    println!("{:?} ", i);
+                                }
+                                CASS_VALUE_TYPE_SET => {
+                                    let phone_numbers = cass_iterator_from_collection(field_value);
+                                    while cass_iterator_next(phone_numbers) == cass_true {
+                                        let phone_value = cass_iterator_get_value(phone_numbers);
+                                        let phone_fields =
+                                            cass_iterator_fields_from_user_type(phone_value);
+                                        assert!(
+                                            cass_value_type(phone_value) == CASS_VALUE_TYPE_UDT
+                                        );
+                                        while cass_iterator_next(phone_fields) == cass_true {
+                                            let phone_number_value =
+                                                cass_iterator_get_user_type_field_value(
+                                                    phone_fields,
+                                                );
+                                            let mut i = mem::zeroed();
+                                            cass_value_get_int32(phone_number_value, &mut i);
+                                            println!("{:?} ", i);
                                         }
                                     }
-                                    _ => print!("<invalid> "),
                                 }
-                            }
+                                _ => print!("<invalid> "),
+                            },
                             cass_true => print!("<null> "),
                         }
-
 
                         println!("");
                     }
@@ -160,7 +191,6 @@ fn select_from_udt(session: &mut CassSession) -> Result<(), CassError> {
                     cass_result_free(result);
                     cass_iterator_free(rows);
                 }
-
             }
             _ => print_error(future),
         }
@@ -193,14 +223,18 @@ fn main() {
                        'replication_factor': '3' }")
             .unwrap();
 
-        execute_query(session,
-                      "CREATE TYPE IF NOT EXISTS examples.phone_numbers (phone1 int, phone2 int)")
-            .unwrap();
+        execute_query(
+            session,
+            "CREATE TYPE IF NOT EXISTS examples.phone_numbers (phone1 int, phone2 int)",
+        )
+        .unwrap();
 
-        execute_query(session,
-                      "CREATE TYPE IF NOT EXISTS examples.address (street text, city text, zip int, phone \
-                       set<frozen<phone_numbers>>)")
-            .unwrap();
+        execute_query(
+            session,
+            "CREATE TYPE IF NOT EXISTS examples.address (street text, city text, zip int, phone \
+                       set<frozen<phone_numbers>>)",
+        )
+        .unwrap();
 
         execute_query(session,
                       "CREATE TABLE IF NOT EXISTS examples.udt (id timeuuid, address frozen<address>, PRIMARY \

--- a/examples/uuid.rs
+++ b/examples/uuid.rs
@@ -6,9 +6,9 @@ extern crate cassandra_cpp_sys;
 mod examples_util;
 use examples_util::*;
 
-use std::mem;
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::mem;
 
 use std::str;
 
@@ -16,11 +16,17 @@ use cassandra_cpp_sys::*;
 
 const CASS_UUID_STRING_LENGTH: usize = 37;
 
-fn insert_into_log(session: &mut CassSession, key: &str, time: CassUuid, entry: &str) -> Result<(), CassError> {
+fn insert_into_log(
+    session: &mut CassSession,
+    key: &str,
+    time: CassUuid,
+    entry: &str,
+) -> Result<(), CassError> {
     unsafe {
         let query = "INSERT INTO examples.log (key, time, entry) VALUES (?, ?, ?);";
 
-        let statement: *mut CassStatement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 3);
+        let statement: *mut CassStatement =
+            cass_statement_new(CString::new(query).unwrap().as_ptr(), 3);
 
         cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());
         cass_statement_bind_uuid(statement, 1, time);
@@ -71,11 +77,17 @@ fn select_from_log(session: &mut CassSession, key: &str) -> Result<(), CassError
                     let mut entry_length = mem::zeroed();
                     let mut time_str: [i8; CASS_UUID_STRING_LENGTH] = [0; CASS_UUID_STRING_LENGTH];
 
-                    cass_value_get_string(cass_row_get_column(row, 0),
-                                          &mut CString::new(key).unwrap().as_ptr(),
-                                          &mut key_length);
+                    cass_value_get_string(
+                        cass_row_get_column(row, 0),
+                        &mut CString::new(key).unwrap().as_ptr(),
+                        &mut key_length,
+                    );
                     cass_value_get_uuid(cass_row_get_column(row, 1), &mut time);
-                    cass_value_get_string(cass_row_get_column(row, 2), &mut entry, &mut entry_length);
+                    cass_value_get_string(
+                        cass_row_get_column(row, 2),
+                        &mut entry,
+                        &mut entry_length,
+                    );
                     let mut output: i8 = mem::zeroed();
                     cass_uuid_string(time, &mut output);
                     let output = CStr::from_ptr(&output);
@@ -108,10 +120,12 @@ pub fn main() {
 
         match connect_session(session, cluster) {
             Ok(()) => {
-                execute_query(&mut *session,
-                              "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
-                               'SimpleStrategy', 'replication_factor': '1' };")
-                    .unwrap();
+                execute_query(
+                    &mut *session,
+                    "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': \
+                               'SimpleStrategy', 'replication_factor': '1' };",
+                )
+                .unwrap();
                 execute_query(&mut *session,
                               "CREATE TABLE IF NOT EXISTS examples.log (key text, time timeuuid, entry text, PRIMARY \
                                KEY (key, time));")

--- a/src/cassandra.rs
+++ b/src/cassandra.rs
@@ -803,10 +803,7 @@ pub use self::CassError_ as CassError;
 ///
 /// @see cass_future_set_callback()
 pub type CassFutureCallback = ::std::option::Option<
-    unsafe extern "C" fn(
-        future: *mut CassFuture,
-        data: *mut ::std::os::raw::c_void,
-    ),
+    unsafe extern "C" fn(future: *mut CassFuture, data: *mut ::std::os::raw::c_void),
 >;
 /// A log message.
 #[repr(C)]
@@ -834,10 +831,7 @@ pub type CassLogMessage = CassLogMessage_;
 ///
 /// @see cass_log_set_callback()
 pub type CassLogCallback = ::std::option::Option<
-    unsafe extern "C" fn(
-        message: *const CassLogMessage,
-        data: *mut ::std::os::raw::c_void,
-    ),
+    unsafe extern "C" fn(message: *const CassLogMessage, data: *mut ::std::os::raw::c_void),
 >;
 /// A custom malloc function. This function should allocate "size" bytes and
 /// return a pointer to that memory
@@ -846,9 +840,8 @@ pub type CassLogCallback = ::std::option::Option<
 ///
 /// @see CassFreeFunction
 /// @see cass_alloc_set_functions()
-pub type CassMallocFunction = ::std::option::Option<
-    unsafe extern "C" fn(size: usize) -> *mut ::std::os::raw::c_void,
->;
+pub type CassMallocFunction =
+    ::std::option::Option<unsafe extern "C" fn(size: usize) -> *mut ::std::os::raw::c_void>;
 /// A custom realloc function. This function attempts to change the size of the
 /// memory pointed to by "ptr". If the memory cannot be resized then new memory
 /// should be allocated and contain the contents of the original memory at "ptr".
@@ -861,8 +854,10 @@ pub type CassMallocFunction = ::std::option::Option<
 /// @see CassFreeFunction
 /// @see cass_alloc_set_functions()
 pub type CassReallocFunction = ::std::option::Option<
-    unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void, size: usize)
-        -> *mut ::std::os::raw::c_void,
+    unsafe extern "C" fn(
+        ptr: *mut ::std::os::raw::c_void,
+        size: usize,
+    ) -> *mut ::std::os::raw::c_void,
 >;
 /// A custom free function. This function deallocates the memory pointed to by
 /// "ptr" that was previously allocated by a "CassMallocFunction" or
@@ -874,9 +869,8 @@ pub type CassReallocFunction = ::std::option::Option<
 /// @see CassMallocFunction
 /// @see CassReallocFunction
 /// @see cass_alloc_set_functions()
-pub type CassFreeFunction = ::std::option::Option<
-    unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void),
->;
+pub type CassFreeFunction =
+    ::std::option::Option<unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CassAuthenticator_ {
@@ -896,10 +890,7 @@ pub type CassAuthenticator = CassAuthenticator_;
 /// @param[in] auth
 /// @param[in] data
 pub type CassAuthenticatorInitialCallback = ::std::option::Option<
-    unsafe extern "C" fn(
-        auth: *mut CassAuthenticator,
-        data: *mut ::std::os::raw::c_void,
-    ),
+    unsafe extern "C" fn(auth: *mut CassAuthenticator, data: *mut ::std::os::raw::c_void),
 >;
 /// A callback used when an authentication challenge initiated
 /// by the server.
@@ -946,17 +937,13 @@ pub type CassAuthenticatorSuccessCallback = ::std::option::Option<
 /// @param[in] auth
 /// @param[in] data
 pub type CassAuthenticatorCleanupCallback = ::std::option::Option<
-    unsafe extern "C" fn(
-        auth: *mut CassAuthenticator,
-        data: *mut ::std::os::raw::c_void,
-    ),
+    unsafe extern "C" fn(auth: *mut CassAuthenticator, data: *mut ::std::os::raw::c_void),
 >;
 /// A callback used to cleanup resources.
 ///
 /// @param[in] data
-pub type CassAuthenticatorDataCleanupCallback = ::std::option::Option<
-    unsafe extern "C" fn(data: *mut ::std::os::raw::c_void),
->;
+pub type CassAuthenticatorDataCleanupCallback =
+    ::std::option::Option<unsafe extern "C" fn(data: *mut ::std::os::raw::c_void)>;
 /// Authenticator callbacks
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2001,10 +1988,7 @@ extern "C" {
     ///
     /// @param[in] cluster
     /// @param[in] enabled
-    pub fn cass_cluster_set_token_aware_routing(
-        cluster: *mut CassCluster,
-        enabled: cass_bool_t,
-    );
+    pub fn cass_cluster_set_token_aware_routing(cluster: *mut CassCluster, enabled: cass_bool_t);
 }
 extern "C" {
     /// Configures token-aware routing to randomly shuffle replicas. This can reduce
@@ -2038,10 +2022,7 @@ extern "C" {
     ///
     /// @param[in] cluster
     /// @param[in] enabled
-    pub fn cass_cluster_set_latency_aware_routing(
-        cluster: *mut CassCluster,
-        enabled: cass_bool_t,
-    );
+    pub fn cass_cluster_set_latency_aware_routing(cluster: *mut CassCluster, enabled: cass_bool_t);
 }
 extern "C" {
     /// Configures the settings for latency-aware request routing.
@@ -2239,10 +2220,7 @@ extern "C" {
     ///
     /// @param[in] cluster
     /// @param[in] enabled
-    pub fn cass_cluster_set_tcp_nodelay(
-        cluster: *mut CassCluster,
-        enabled: cass_bool_t,
-    );
+    pub fn cass_cluster_set_tcp_nodelay(cluster: *mut CassCluster, enabled: cass_bool_t);
 }
 extern "C" {
     /// Enable/Disable TCP keep-alive
@@ -2351,10 +2329,7 @@ extern "C" {
     /// @param[in] enabled
     ///
     /// @see cass_session_get_schema_meta()
-    pub fn cass_cluster_set_use_schema(
-        cluster: *mut CassCluster,
-        enabled: cass_bool_t,
-    );
+    pub fn cass_cluster_set_use_schema(cluster: *mut CassCluster, enabled: cass_bool_t);
 }
 extern "C" {
     /// Enable/Disable retrieving hostnames for IP addresses using reverse IP lookup.
@@ -2418,9 +2393,8 @@ extern "C" {
     ///
     /// @param[in] cluster
     /// @return CASS_OK if successful, otherwise an error occurred
-    pub fn cass_cluster_set_no_speculative_execution_policy(
-        cluster: *mut CassCluster,
-    ) -> CassError;
+    pub fn cass_cluster_set_no_speculative_execution_policy(cluster: *mut CassCluster)
+        -> CassError;
 }
 extern "C" {
     /// Sets the maximum number of "pending write" objects that will be
@@ -2728,9 +2702,7 @@ extern "C" {
     /// @return A schema instance that must be freed.
     ///
     /// @see cass_schema_meta_free()
-    pub fn cass_session_get_schema_meta(
-        session: *const CassSession,
-    ) -> *const CassSchemaMeta;
+    pub fn cass_session_get_schema_meta(session: *const CassSession) -> *const CassSchemaMeta;
 }
 extern "C" {
     /// Gets a copy of this session's performance/diagnostic metrics.
@@ -2739,10 +2711,7 @@ extern "C" {
     ///
     /// @param[in] session
     /// @param[out] output
-    pub fn cass_session_get_metrics(
-        session: *const CassSession,
-        output: *mut CassMetrics,
-    );
+    pub fn cass_session_get_metrics(session: *const CassSession, output: *mut CassMetrics);
 }
 extern "C" {
     /// Gets a copy of this session's speculative execution metrics.
@@ -2772,9 +2741,7 @@ extern "C" {
     /// @param[in] schema_meta
     ///
     /// @return The snapshot version.
-    pub fn cass_schema_meta_snapshot_version(
-        schema_meta: *const CassSchemaMeta,
-    ) -> cass_uint32_t;
+    pub fn cass_schema_meta_snapshot_version(schema_meta: *const CassSchemaMeta) -> cass_uint32_t;
 }
 extern "C" {
     /// Gets the version of the connected Cassandra cluster.
@@ -2784,9 +2751,7 @@ extern "C" {
     /// @param[in] schema_meta
     ///
     /// @return Cassandra's version
-    pub fn cass_schema_meta_version(
-        schema_meta: *const CassSchemaMeta,
-    ) -> CassVersion;
+    pub fn cass_schema_meta_version(schema_meta: *const CassSchemaMeta) -> CassVersion;
 }
 extern "C" {
     /// Gets the keyspace metadata for the provided keyspace name.
@@ -2841,9 +2806,7 @@ extern "C" {
     ///
     /// @param[in] keyspace_meta
     /// @return cass_true is the keyspace is virtual, otherwise cass_false
-    pub fn cass_keyspace_meta_is_virtual(
-        keyspace_meta: *const CassKeyspaceMeta,
-    ) -> cass_bool_t;
+    pub fn cass_keyspace_meta_is_virtual(keyspace_meta: *const CassKeyspaceMeta) -> cass_bool_t;
 }
 extern "C" {
     /// Gets the table metadata for the provided table name.
@@ -3088,9 +3051,7 @@ extern "C" {
     ///
     /// @param[in] table_meta
     /// @return cass_true is the table is virtual, otherwise cass_false
-    pub fn cass_table_meta_is_virtual(
-        table_meta: *const CassTableMeta,
-    ) -> cass_bool_t;
+    pub fn cass_table_meta_is_virtual(table_meta: *const CassTableMeta) -> cass_bool_t;
 }
 extern "C" {
     /// Gets the column metadata for the provided column name.
@@ -3131,9 +3092,7 @@ extern "C" {
     ///
     /// @param[in] table_meta
     /// @return The total column count.
-    pub fn cass_table_meta_column_count(
-        table_meta: *const CassTableMeta,
-    ) -> usize;
+    pub fn cass_table_meta_column_count(table_meta: *const CassTableMeta) -> usize;
 }
 extern "C" {
     /// Gets the column metadata for the provided index.
@@ -3187,9 +3146,7 @@ extern "C" {
     ///
     /// @param[in] table_meta
     /// @return The total index count.
-    pub fn cass_table_meta_index_count(
-        table_meta: *const CassTableMeta,
-    ) -> usize;
+    pub fn cass_table_meta_index_count(table_meta: *const CassTableMeta) -> usize;
 }
 extern "C" {
     /// Gets the index metadata for the provided index.
@@ -3249,9 +3206,7 @@ extern "C" {
     ///
     /// @param[in] table_meta
     /// @return The total view count.
-    pub fn cass_table_meta_materialized_view_count(
-        table_meta: *const CassTableMeta,
-    ) -> usize;
+    pub fn cass_table_meta_materialized_view_count(table_meta: *const CassTableMeta) -> usize;
 }
 extern "C" {
     /// Gets the materialized view metadata for the provided index.
@@ -3275,9 +3230,7 @@ extern "C" {
     ///
     /// @param[in] table_meta
     /// @return The count for the number of columns in the partition key.
-    pub fn cass_table_meta_partition_key_count(
-        table_meta: *const CassTableMeta,
-    ) -> usize;
+    pub fn cass_table_meta_partition_key_count(table_meta: *const CassTableMeta) -> usize;
 }
 extern "C" {
     /// Gets the partition key column metadata for the provided index.
@@ -3301,9 +3254,7 @@ extern "C" {
     ///
     /// @param[in] table_meta
     /// @return The count for the number of columns in the clustering key.
-    pub fn cass_table_meta_clustering_key_count(
-        table_meta: *const CassTableMeta,
-    ) -> usize;
+    pub fn cass_table_meta_clustering_key_count(table_meta: *const CassTableMeta) -> usize;
 }
 extern "C" {
     /// Gets the clustering key column metadata for the provided index.
@@ -3591,9 +3542,7 @@ extern "C" {
     ///
     /// @param[in] column_meta
     /// @return The column's type.
-    pub fn cass_column_meta_type(
-        column_meta: *const CassColumnMeta,
-    ) -> CassColumnType;
+    pub fn cass_column_meta_type(column_meta: *const CassColumnMeta) -> CassColumnType;
 }
 extern "C" {
     /// Gets the data type of the column.
@@ -3602,9 +3551,7 @@ extern "C" {
     ///
     /// @param[in] column_meta
     /// @return The column's data type.
-    pub fn cass_column_meta_data_type(
-        column_meta: *const CassColumnMeta,
-    ) -> *const CassDataType;
+    pub fn cass_column_meta_data_type(column_meta: *const CassColumnMeta) -> *const CassDataType;
 }
 extern "C" {
     /// Gets a metadata field for the provided name. Metadata fields allow direct
@@ -3659,9 +3606,7 @@ extern "C" {
     ///
     /// @param[in] index_meta
     /// @return The index's type.
-    pub fn cass_index_meta_type(
-        index_meta: *const CassIndexMeta,
-    ) -> CassIndexType;
+    pub fn cass_index_meta_type(index_meta: *const CassIndexMeta) -> CassIndexType;
 }
 extern "C" {
     /// Gets the target of the index.
@@ -3684,9 +3629,7 @@ extern "C" {
     ///
     /// @param[in] index_meta
     /// @return The index's options.
-    pub fn cass_index_meta_options(
-        index_meta: *const CassIndexMeta,
-    ) -> *const CassValue;
+    pub fn cass_index_meta_options(index_meta: *const CassIndexMeta) -> *const CassValue;
 }
 extern "C" {
     /// Gets a metadata field for the provided name. Metadata fields allow direct
@@ -3808,9 +3751,7 @@ extern "C" {
     ///
     /// @param[in] function_meta
     /// @return The number of arguments.
-    pub fn cass_function_meta_argument_count(
-        function_meta: *const CassFunctionMeta,
-    ) -> usize;
+    pub fn cass_function_meta_argument_count(function_meta: *const CassFunctionMeta) -> usize;
 }
 extern "C" {
     /// Gets the function's argument name and type for the provided index.
@@ -3960,9 +3901,7 @@ extern "C" {
     ///
     /// @param[in] aggregate_meta
     /// @return The number of arguments.
-    pub fn cass_aggregate_meta_argument_count(
-        aggregate_meta: *const CassAggregateMeta,
-    ) -> usize;
+    pub fn cass_aggregate_meta_argument_count(aggregate_meta: *const CassAggregateMeta) -> usize;
 }
 extern "C" {
     /// Gets the aggregate's argument type for the provided index.
@@ -4183,10 +4122,7 @@ extern "C" {
     /// @return CASS_OK if successful, otherwise an error occurred
     ///
     /// @see cass_cluster_set_use_hostname_resolution()
-    pub fn cass_ssl_set_verify_flags(
-        ssl: *mut CassSsl,
-        flags: ::std::os::raw::c_int,
-    );
+    pub fn cass_ssl_set_verify_flags(ssl: *mut CassSsl, flags: ::std::os::raw::c_int);
 }
 extern "C" {
     /// Set client-side certificate chain. This is used to authenticate
@@ -4198,10 +4134,7 @@ extern "C" {
     /// @param[in] ssl
     /// @param[in] cert PEM formatted certificate string
     /// @return CASS_OK if successful, otherwise an error occurred
-    pub fn cass_ssl_set_cert(
-        ssl: *mut CassSsl,
-        cert: *const ::std::os::raw::c_char,
-    ) -> CassError;
+    pub fn cass_ssl_set_cert(ssl: *mut CassSsl, cert: *const ::std::os::raw::c_char) -> CassError;
 }
 extern "C" {
     /// Same as cass_ssl_set_cert(), but with lengths for string
@@ -4266,10 +4199,7 @@ extern "C" {
     /// @param[out] address
     ///
     /// @public @memberof CassAuthenticator
-    pub fn cass_authenticator_address(
-        auth: *const CassAuthenticator,
-        address: *mut CassInet,
-    );
+    pub fn cass_authenticator_address(auth: *const CassAuthenticator, address: *mut CassInet);
 }
 extern "C" {
     /// Gets the hostname of the host being authenticated.
@@ -4447,8 +4377,7 @@ extern "C" {
     /// must be freed using cass_result_free().
     ///
     /// @see cass_session_execute() and cass_session_execute_batch()
-    pub fn cass_future_get_result(future: *mut CassFuture)
-        -> *const CassResult;
+    pub fn cass_future_get_result(future: *mut CassFuture) -> *const CassResult;
 }
 extern "C" {
     /// Gets the error result from a future that failed as a result of a server error. If the
@@ -4462,9 +4391,7 @@ extern "C" {
     /// a server error. The return instance must be freed using cass_error_result_free().
     ///
     /// @see cass_session_execute() and cass_session_execute_batch()
-    pub fn cass_future_get_error_result(
-        future: *mut CassFuture,
-    ) -> *const CassErrorResult;
+    pub fn cass_future_get_error_result(future: *mut CassFuture) -> *const CassErrorResult;
 }
 extern "C" {
     /// Gets the result of a successful future. If the future is not ready this method will
@@ -4478,9 +4405,7 @@ extern "C" {
     /// must be freed using cass_prepared_free().
     ///
     /// @see cass_session_prepare()
-    pub fn cass_future_get_prepared(
-        future: *mut CassFuture,
-    ) -> *const CassPrepared;
+    pub fn cass_future_get_prepared(future: *mut CassFuture) -> *const CassPrepared;
 }
 extern "C" {
     /// Gets the error code from future. If the future is not ready this method will
@@ -4520,9 +4445,7 @@ extern "C" {
     ///
     /// @param[in] future
     /// @return the number of custom payload items.
-    pub fn cass_future_custom_payload_item_count(
-        future: *mut CassFuture,
-    ) -> usize;
+    pub fn cass_future_custom_payload_item_count(future: *mut CassFuture) -> usize;
 }
 extern "C" {
     /// Gets a custom payload item from a response future at the specified index. If the future is not
@@ -4620,10 +4543,7 @@ extern "C" {
     /// @param[in] statement
     /// @param[in] index
     /// @return CASS_OK if successful, otherwise an error occurred.
-    pub fn cass_statement_add_key_index(
-        statement: *mut CassStatement,
-        index: usize,
-    ) -> CassError;
+    pub fn cass_statement_add_key_index(statement: *mut CassStatement, index: usize) -> CassError;
 }
 extern "C" {
     /// Sets the statement's keyspace. This is used for token-aware routing and when
@@ -4836,10 +4756,7 @@ extern "C" {
     /// @param[in] statement
     /// @param[in] index
     /// @return CASS_OK if successful, otherwise an error occurred.
-    pub fn cass_statement_bind_null(
-        statement: *mut CassStatement,
-        index: usize,
-    ) -> CassError;
+    pub fn cass_statement_bind_null(statement: *mut CassStatement, index: usize) -> CassError;
 }
 extern "C" {
     /// Binds a null to all the values with the specified name.
@@ -6006,9 +5923,7 @@ extern "C" {
     /// @return Returns a bound statement that must be freed.
     ///
     /// @see cass_statement_free()
-    pub fn cass_prepared_bind(
-        prepared: *const CassPrepared,
-    ) -> *mut CassStatement;
+    pub fn cass_prepared_bind(prepared: *const CassPrepared) -> *mut CassStatement;
 }
 extern "C" {
     /// Gets the name of a parameter at the specified index.
@@ -6175,10 +6090,7 @@ extern "C" {
     /// @param[in] batch
     /// @param[in] timestamp
     /// @return CASS_OK if successful, otherwise an error occurred.
-    pub fn cass_batch_set_timestamp(
-        batch: *mut CassBatch,
-        timestamp: cass_int64_t,
-    ) -> CassError;
+    pub fn cass_batch_set_timestamp(batch: *mut CassBatch, timestamp: cass_int64_t) -> CassError;
 }
 extern "C" {
     /// Sets the batch's timeout for waiting for a response from a node.
@@ -6316,9 +6228,7 @@ extern "C" {
     /// @return Returns a data type that must be freed.
     ///
     /// @see cass_data_type_free()
-    pub fn cass_data_type_new_from_existing(
-        data_type: *const CassDataType,
-    ) -> *mut CassDataType;
+    pub fn cass_data_type_new_from_existing(data_type: *const CassDataType) -> *mut CassDataType;
 }
 extern "C" {
     /// Creates a new tuple data type.
@@ -6359,8 +6269,7 @@ extern "C" {
     ///
     /// @param[in] data_type
     /// @return The value type
-    pub fn cass_data_type_type(data_type: *const CassDataType)
-        -> CassValueType;
+    pub fn cass_data_type_type(data_type: *const CassDataType) -> CassValueType;
 }
 extern "C" {
     /// Gets whether a data type is frozen.
@@ -6369,9 +6278,7 @@ extern "C" {
     ///
     /// @param[in] data_type
     /// @return cass_true if the data type is frozen, otherwise cass_false.
-    pub fn cass_data_type_is_frozen(
-        data_type: *const CassDataType,
-    ) -> cass_bool_t;
+    pub fn cass_data_type_is_frozen(data_type: *const CassDataType) -> cass_bool_t;
 }
 extern "C" {
     /// Gets the type name of a UDT data type.
@@ -6519,9 +6426,7 @@ extern "C" {
     ///
     /// @param[in] data_type
     /// @return Returns the number of sub-data types
-    pub fn cass_data_type_sub_type_count(
-        data_type: *const CassDataType,
-    ) -> usize;
+    pub fn cass_data_type_sub_type_count(data_type: *const CassDataType) -> usize;
 }
 extern "C" {
     pub fn cass_data_sub_type_count(data_type: *const CassDataType) -> usize;
@@ -6708,10 +6613,8 @@ extern "C" {
     /// @return Returns a collection that must be freed.
     ///
     /// @see cass_collection_free()
-    pub fn cass_collection_new(
-        type_: CassCollectionType,
-        item_count: usize,
-    ) -> *mut CassCollection;
+    pub fn cass_collection_new(type_: CassCollectionType, item_count: usize)
+        -> *mut CassCollection;
 }
 extern "C" {
     /// Creates a new collection from an existing data type.
@@ -6742,9 +6645,7 @@ extern "C" {
     /// @param[in] collection
     /// @return Returns a reference to the data type of the collection. Do not free
     /// this reference as it is bound to the lifetime of the collection.
-    pub fn cass_collection_data_type(
-        collection: *const CassCollection,
-    ) -> *const CassDataType;
+    pub fn cass_collection_data_type(collection: *const CassCollection) -> *const CassDataType;
 }
 extern "C" {
     /// Appends a "tinyint" to the collection.
@@ -7077,9 +6978,7 @@ extern "C" {
     /// @return Returns a tuple that must be freed.
     ///
     /// @see cass_tuple_free();
-    pub fn cass_tuple_new_from_data_type(
-        data_type: *const CassDataType,
-    ) -> *mut CassTuple;
+    pub fn cass_tuple_new_from_data_type(data_type: *const CassDataType) -> *mut CassTuple;
 }
 extern "C" {
     /// Frees a tuple instance.
@@ -7099,8 +6998,7 @@ extern "C" {
     /// @param[in] tuple
     /// @return Returns a reference to the data type of the tuple. Do not free
     /// this reference as it is bound to the lifetime of the tuple.
-    pub fn cass_tuple_data_type(tuple: *const CassTuple)
-        -> *const CassDataType;
+    pub fn cass_tuple_data_type(tuple: *const CassTuple) -> *const CassDataType;
 }
 extern "C" {
     /// Sets an null in a tuple at the specified index.
@@ -7112,10 +7010,7 @@ extern "C" {
     /// @param[in] tuple
     /// @param[in] index
     /// @return CASS_OK if successful, otherwise an error occurred.
-    pub fn cass_tuple_set_null(
-        tuple: *mut CassTuple,
-        index: usize,
-    ) -> CassError;
+    pub fn cass_tuple_set_null(tuple: *mut CassTuple, index: usize) -> CassError;
 }
 extern "C" {
     /// Sets a "tinyint" in a tuple at the specified index.
@@ -7369,11 +7264,7 @@ extern "C" {
     /// @param[in] index
     /// @param[in] value
     /// @return CASS_OK if successful, otherwise an error occurred.
-    pub fn cass_tuple_set_uuid(
-        tuple: *mut CassTuple,
-        index: usize,
-        value: CassUuid,
-    ) -> CassError;
+    pub fn cass_tuple_set_uuid(tuple: *mut CassTuple, index: usize, value: CassUuid) -> CassError;
 }
 extern "C" {
     /// Sets an "inet" in a tuple at the specified index.
@@ -7386,11 +7277,7 @@ extern "C" {
     /// @param[in] index
     /// @param[in] value
     /// @return CASS_OK if successful, otherwise an error occurred.
-    pub fn cass_tuple_set_inet(
-        tuple: *mut CassTuple,
-        index: usize,
-        value: CassInet,
-    ) -> CassError;
+    pub fn cass_tuple_set_inet(tuple: *mut CassTuple, index: usize, value: CassInet) -> CassError;
 }
 extern "C" {
     /// Sets a "decimal" in a tuple at the specified index.
@@ -7498,9 +7385,7 @@ extern "C" {
     /// the data type is not a user defined type.
     ///
     /// @see cass_user_type_free()
-    pub fn cass_user_type_new_from_data_type(
-        data_type: *const CassDataType,
-    ) -> *mut CassUserType;
+    pub fn cass_user_type_new_from_data_type(data_type: *const CassDataType) -> *mut CassUserType;
 }
 extern "C" {
     /// Frees a user defined type instance.
@@ -7521,9 +7406,7 @@ extern "C" {
     /// @return Returns a reference to the data type of the user defined type.
     /// Do not free this reference as it is bound to the lifetime of the
     /// user defined type.
-    pub fn cass_user_type_data_type(
-        user_type: *const CassUserType,
-    ) -> *const CassDataType;
+    pub fn cass_user_type_data_type(user_type: *const CassUserType) -> *const CassDataType;
 }
 extern "C" {
     /// Sets a null in a user defined type at the specified index.
@@ -7535,10 +7418,7 @@ extern "C" {
     /// @param[in] user_type
     /// @param[in] index
     /// @return CASS_OK if successful, otherwise an error occurred.
-    pub fn cass_user_type_set_null(
-        user_type: *mut CassUserType,
-        index: usize,
-    ) -> CassError;
+    pub fn cass_user_type_set_null(user_type: *mut CassUserType, index: usize) -> CassError;
 }
 extern "C" {
     /// Sets a null in a user defined type at the specified name.
@@ -8730,10 +8610,7 @@ extern "C" {
     /// @param[in] index
     /// @return The column type at the specified index. CASS_VALUE_TYPE_UNKNOWN
     /// is returned if the index is out of bounds.
-    pub fn cass_result_column_type(
-        result: *const CassResult,
-        index: usize,
-    ) -> CassValueType;
+    pub fn cass_result_column_type(result: *const CassResult, index: usize) -> CassValueType;
 }
 extern "C" {
     /// Gets the column data type at index for the specified result.
@@ -8767,8 +8644,7 @@ extern "C" {
     ///
     /// @param[in] result
     /// @return cass_true if there are more pages
-    pub fn cass_result_has_more_pages(result: *const CassResult)
-        -> cass_bool_t;
+    pub fn cass_result_has_more_pages(result: *const CassResult) -> cass_bool_t;
 }
 extern "C" {
     /// Gets the raw paging state from the result. The paging state is bound to the
@@ -8811,9 +8687,7 @@ extern "C" {
     ///
     /// @param[in] error_result
     /// @return The server error code
-    pub fn cass_error_result_code(
-        error_result: *const CassErrorResult,
-    ) -> CassError;
+    pub fn cass_error_result_code(error_result: *const CassErrorResult) -> CassError;
 }
 extern "C" {
     /// Gets consistency that triggered the error result of the
@@ -8833,9 +8707,7 @@ extern "C" {
     /// @return The consistency that triggered the error for a read timeout,
     /// write timeout or an unavailable error result. Undefined for other
     /// error result types.
-    pub fn cass_error_result_consistency(
-        error_result: *const CassErrorResult,
-    ) -> CassConsistency;
+    pub fn cass_error_result_consistency(error_result: *const CassErrorResult) -> CassConsistency;
 }
 extern "C" {
     /// Gets the actual number of received responses, received acknowledgments
@@ -8894,9 +8766,7 @@ extern "C" {
     ///
     /// @param[in] error_result
     /// @return The number of nodes that failed during a read or write request.
-    pub fn cass_error_result_num_failures(
-        error_result: *const CassErrorResult,
-    ) -> cass_int32_t;
+    pub fn cass_error_result_num_failures(error_result: *const CassErrorResult) -> cass_int32_t;
 }
 extern "C" {
     /// Determines whether the actual data was present in the responses from the
@@ -8912,9 +8782,7 @@ extern "C" {
     /// @param[in] error_result
     /// @return cass_true if the data was present in the received responses when the
     /// read timeout occurred. Undefined for other error result types.
-    pub fn cass_error_result_data_present(
-        error_result: *const CassErrorResult,
-    ) -> cass_bool_t;
+    pub fn cass_error_result_data_present(error_result: *const CassErrorResult) -> cass_bool_t;
 }
 extern "C" {
     /// Gets the write type of a request for the following error result types:
@@ -8929,9 +8797,7 @@ extern "C" {
     /// @param[in] error_result
     /// @return The type of the write that timed out. Undefined for
     /// other error result types.
-    pub fn cass_error_result_write_type(
-        error_result: *const CassErrorResult,
-    ) -> CassWriteType;
+    pub fn cass_error_result_write_type(error_result: *const CassErrorResult) -> CassWriteType;
 }
 extern "C" {
     /// Gets the affected keyspace for the following error result types:
@@ -8997,9 +8863,7 @@ extern "C" {
     ///
     /// @param[in] error_result
     /// @return The number of arguments for the affected function.
-    pub fn cass_error_num_arg_types(
-        error_result: *const CassErrorResult,
-    ) -> usize;
+    pub fn cass_error_num_arg_types(error_result: *const CassErrorResult) -> usize;
 }
 extern "C" {
     /// Gets the argument type at the specified index for the function failure
@@ -9048,9 +8912,7 @@ extern "C" {
     /// @return A new iterator that must be freed.
     ///
     /// @see cass_iterator_free()
-    pub fn cass_iterator_from_result(
-        result: *const CassResult,
-    ) -> *mut CassIterator;
+    pub fn cass_iterator_from_result(result: *const CassResult) -> *mut CassIterator;
 }
 extern "C" {
     /// Creates a new iterator for the specified row. This can be
@@ -9075,9 +8937,7 @@ extern "C" {
     /// value is not a collection.
     ///
     /// @see cass_iterator_free()
-    pub fn cass_iterator_from_collection(
-        value: *const CassValue,
-    ) -> *mut CassIterator;
+    pub fn cass_iterator_from_collection(value: *const CassValue) -> *mut CassIterator;
 }
 extern "C" {
     /// Creates a new iterator for the specified map. This can be
@@ -9090,8 +8950,7 @@ extern "C" {
     /// value is not a map.
     ///
     /// @see cass_iterator_free()
-    pub fn cass_iterator_from_map(value: *const CassValue)
-        -> *mut CassIterator;
+    pub fn cass_iterator_from_map(value: *const CassValue) -> *mut CassIterator;
 }
 extern "C" {
     /// Creates a new iterator for the specified tuple. This can be
@@ -9106,9 +8965,7 @@ extern "C" {
     /// value is not a tuple.
     ///
     /// @see cass_iterator_free()
-    pub fn cass_iterator_from_tuple(
-        value: *const CassValue,
-    ) -> *mut CassIterator;
+    pub fn cass_iterator_from_tuple(value: *const CassValue) -> *mut CassIterator;
 }
 extern "C" {
     /// Creates a new iterator for the specified user defined type. This can be
@@ -9123,9 +8980,7 @@ extern "C" {
     /// value is not a user defined type.
     ///
     /// @see cass_iterator_free()
-    pub fn cass_iterator_fields_from_user_type(
-        value: *const CassValue,
-    ) -> *mut CassIterator;
+    pub fn cass_iterator_fields_from_user_type(value: *const CassValue) -> *mut CassIterator;
 }
 extern "C" {
     /// Creates a new iterator for the specified schema metadata.
@@ -9438,9 +9293,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A row
-    pub fn cass_iterator_get_row(
-        iterator: *const CassIterator,
-    ) -> *const CassRow;
+    pub fn cass_iterator_get_row(iterator: *const CassIterator) -> *const CassRow;
 }
 extern "C" {
     /// Gets the column value at the row iterator's current position.
@@ -9452,9 +9305,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A value
-    pub fn cass_iterator_get_column(
-        iterator: *const CassIterator,
-    ) -> *const CassValue;
+    pub fn cass_iterator_get_column(iterator: *const CassIterator) -> *const CassValue;
 }
 extern "C" {
     /// Gets the value at a collection or tuple iterator's current position.
@@ -9466,9 +9317,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A value
-    pub fn cass_iterator_get_value(
-        iterator: *const CassIterator,
-    ) -> *const CassValue;
+    pub fn cass_iterator_get_value(iterator: *const CassIterator) -> *const CassValue;
 }
 extern "C" {
     /// Gets the key at the map iterator's current position.
@@ -9480,9 +9329,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A value
-    pub fn cass_iterator_get_map_key(
-        iterator: *const CassIterator,
-    ) -> *const CassValue;
+    pub fn cass_iterator_get_map_key(iterator: *const CassIterator) -> *const CassValue;
 }
 extern "C" {
     /// Gets the value at the map iterator's current position.
@@ -9494,9 +9341,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A value
-    pub fn cass_iterator_get_map_value(
-        iterator: *const CassIterator,
-    ) -> *const CassValue;
+    pub fn cass_iterator_get_map_value(iterator: *const CassIterator) -> *const CassValue;
 }
 extern "C" {
     /// Gets the field name at the user type defined iterator's current position.
@@ -9558,9 +9403,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A table metadata entry
-    pub fn cass_iterator_get_table_meta(
-        iterator: *const CassIterator,
-    ) -> *const CassTableMeta;
+    pub fn cass_iterator_get_table_meta(iterator: *const CassIterator) -> *const CassTableMeta;
 }
 extern "C" {
     /// Gets the materialized view metadata entry at the iterator's current position.
@@ -9590,9 +9433,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A type metadata entry
-    pub fn cass_iterator_get_user_type(
-        iterator: *const CassIterator,
-    ) -> *const CassDataType;
+    pub fn cass_iterator_get_user_type(iterator: *const CassIterator) -> *const CassDataType;
 }
 extern "C" {
     /// Gets the function metadata entry at the iterator's current position.
@@ -9636,9 +9477,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A column metadata entry
-    pub fn cass_iterator_get_column_meta(
-        iterator: *const CassIterator,
-    ) -> *const CassColumnMeta;
+    pub fn cass_iterator_get_column_meta(iterator: *const CassIterator) -> *const CassColumnMeta;
 }
 extern "C" {
     /// Gets the index metadata entry at the iterator's current position.
@@ -9650,9 +9489,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A index metadata entry
-    pub fn cass_iterator_get_index_meta(
-        iterator: *const CassIterator,
-    ) -> *const CassIndexMeta;
+    pub fn cass_iterator_get_index_meta(iterator: *const CassIterator) -> *const CassIndexMeta;
 }
 extern "C" {
     /// Gets the metadata field name at the iterator's current position.
@@ -9682,9 +9519,7 @@ extern "C" {
     ///
     /// @param[in] iterator
     /// @return A metadata field value
-    pub fn cass_iterator_get_meta_field_value(
-        iterator: *const CassIterator,
-    ) -> *const CassValue;
+    pub fn cass_iterator_get_meta_field_value(iterator: *const CassIterator) -> *const CassValue;
 }
 extern "C" {
     /// Get the column value at index for the specified row.
@@ -9695,10 +9530,7 @@ extern "C" {
     /// @param[in] index
     /// @return The column value at the specified index. NULL is
     /// returned if the index is out of bounds.
-    pub fn cass_row_get_column(
-        row: *const CassRow,
-        index: usize,
-    ) -> *const CassValue;
+    pub fn cass_row_get_column(row: *const CassRow, index: usize) -> *const CassValue;
 }
 extern "C" {
     /// Get the column value by name for the specified row.
@@ -9740,8 +9572,7 @@ extern "C" {
     /// @param[in] value
     /// @return Returns a reference to the data type of the value.
     /// Do not free this reference as it is bound to the lifetime of the value.
-    pub fn cass_value_data_type(value: *const CassValue)
-        -> *const CassDataType;
+    pub fn cass_value_data_type(value: *const CassValue) -> *const CassDataType;
 }
 extern "C" {
     /// Gets an int8 for the specified value.
@@ -9753,10 +9584,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_int8(
-        value: *const CassValue,
-        output: *mut cass_int8_t,
-    ) -> CassError;
+    pub fn cass_value_get_int8(value: *const CassValue, output: *mut cass_int8_t) -> CassError;
 }
 extern "C" {
     /// Gets an int16 for the specified value.
@@ -9768,10 +9596,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_int16(
-        value: *const CassValue,
-        output: *mut cass_int16_t,
-    ) -> CassError;
+    pub fn cass_value_get_int16(value: *const CassValue, output: *mut cass_int16_t) -> CassError;
 }
 extern "C" {
     /// Gets an int32 for the specified value.
@@ -9781,10 +9606,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_int32(
-        value: *const CassValue,
-        output: *mut cass_int32_t,
-    ) -> CassError;
+    pub fn cass_value_get_int32(value: *const CassValue, output: *mut cass_int32_t) -> CassError;
 }
 extern "C" {
     /// Gets an uint32 for the specified value.
@@ -9796,10 +9618,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_uint32(
-        value: *const CassValue,
-        output: *mut cass_uint32_t,
-    ) -> CassError;
+    pub fn cass_value_get_uint32(value: *const CassValue, output: *mut cass_uint32_t) -> CassError;
 }
 extern "C" {
     /// Gets an int64 for the specified value.
@@ -9809,10 +9628,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_int64(
-        value: *const CassValue,
-        output: *mut cass_int64_t,
-    ) -> CassError;
+    pub fn cass_value_get_int64(value: *const CassValue, output: *mut cass_int64_t) -> CassError;
 }
 extern "C" {
     /// Gets a float for the specified value.
@@ -9822,10 +9638,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_float(
-        value: *const CassValue,
-        output: *mut cass_float_t,
-    ) -> CassError;
+    pub fn cass_value_get_float(value: *const CassValue, output: *mut cass_float_t) -> CassError;
 }
 extern "C" {
     /// Gets a double for the specified value.
@@ -9835,10 +9648,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_double(
-        value: *const CassValue,
-        output: *mut cass_double_t,
-    ) -> CassError;
+    pub fn cass_value_get_double(value: *const CassValue, output: *mut cass_double_t) -> CassError;
 }
 extern "C" {
     /// Gets a bool for the specified value.
@@ -9848,10 +9658,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_bool(
-        value: *const CassValue,
-        output: *mut cass_bool_t,
-    ) -> CassError;
+    pub fn cass_value_get_bool(value: *const CassValue, output: *mut cass_bool_t) -> CassError;
 }
 extern "C" {
     /// Gets a UUID for the specified value.
@@ -9861,10 +9668,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_uuid(
-        value: *const CassValue,
-        output: *mut CassUuid,
-    ) -> CassError;
+    pub fn cass_value_get_uuid(value: *const CassValue, output: *mut CassUuid) -> CassError;
 }
 extern "C" {
     /// Gets an INET for the specified value.
@@ -9874,10 +9678,7 @@ extern "C" {
     /// @param[in] value
     /// @param[out] output
     /// @return CASS_OK if successful, otherwise error occurred
-    pub fn cass_value_get_inet(
-        value: *const CassValue,
-        output: *mut CassInet,
-    ) -> CassError;
+    pub fn cass_value_get_inet(value: *const CassValue, output: *mut CassInet) -> CassError;
 }
 extern "C" {
     /// Gets a string for the specified value.
@@ -9999,9 +9800,7 @@ extern "C" {
     /// @param[in] collection
     /// @return The type of the primary sub-type. CASS_VALUE_TYPE_UNKNOWN
     /// returned if not a collection.
-    pub fn cass_value_primary_sub_type(
-        collection: *const CassValue,
-    ) -> CassValueType;
+    pub fn cass_value_primary_sub_type(collection: *const CassValue) -> CassValueType;
 }
 extern "C" {
     /// Get the secondary sub-type for a collection. This returns the value type for a
@@ -10012,9 +9811,7 @@ extern "C" {
     /// @param[in] collection
     /// @return The type of the primary sub-type. CASS_VALUE_TYPE_UNKNOWN
     /// returned if not a collection or not a map.
-    pub fn cass_value_secondary_sub_type(
-        collection: *const CassValue,
-    ) -> CassValueType;
+    pub fn cass_value_secondary_sub_type(collection: *const CassValue) -> CassValueType;
 }
 extern "C" {
     /// Creates a new UUID generator.
@@ -10044,8 +9841,7 @@ extern "C" {
     /// @return Returns a UUID generator that must be freed.
     ///
     /// @see cass_uuid_gen_free()
-    pub fn cass_uuid_gen_new_with_node(node: cass_uint64_t)
-        -> *mut CassUuidGen;
+    pub fn cass_uuid_gen_new_with_node(node: cass_uint64_t) -> *mut CassUuidGen;
 }
 extern "C" {
     /// Frees a UUID generator instance.
@@ -10064,10 +9860,7 @@ extern "C" {
     ///
     /// @param[in] uuid_gen
     /// @param[out] output A V1 UUID for the current time.
-    pub fn cass_uuid_gen_time(
-        uuid_gen: *mut CassUuidGen,
-        output: *mut CassUuid,
-    );
+    pub fn cass_uuid_gen_time(uuid_gen: *mut CassUuidGen, output: *mut CassUuid);
 }
 extern "C" {
     /// Generates a new V4 (random) UUID
@@ -10078,10 +9871,7 @@ extern "C" {
     ///
     /// @param[in] uuid_gen
     /// @param output A randomly generated V4 UUID.
-    pub fn cass_uuid_gen_random(
-        uuid_gen: *mut CassUuidGen,
-        output: *mut CassUuid,
-    );
+    pub fn cass_uuid_gen_random(uuid_gen: *mut CassUuidGen, output: *mut CassUuid);
 }
 extern "C" {
     /// Generates a V1 (time) UUID for the specified time.
@@ -10144,10 +9934,7 @@ extern "C" {
     ///
     /// @param[in] uuid
     /// @param[out] output A null-terminated string of length CASS_UUID_STRING_LENGTH.
-    pub fn cass_uuid_string(
-        uuid: CassUuid,
-        output: *mut ::std::os::raw::c_char,
-    );
+    pub fn cass_uuid_string(uuid: CassUuid, output: *mut ::std::os::raw::c_char);
 }
 extern "C" {
     /// Returns a UUID for the specified string.
@@ -10302,8 +10089,7 @@ extern "C" {
     /// @return Returns a retry policy that must be freed.
     ///
     /// @see cass_retry_policy_free()
-    pub fn cass_retry_policy_downgrading_consistency_new(
-) -> *mut CassRetryPolicy;
+    pub fn cass_retry_policy_downgrading_consistency_new() -> *mut CassRetryPolicy;
 }
 extern "C" {
     /// Creates a new fallthrough retry policy.
@@ -10441,9 +10227,7 @@ extern "C" {
     /// @param[in] consistency
     /// @return A null-terminated string for the consistency.
     /// Example: "ALL", "ONE", "QUORUM", etc.
-    pub fn cass_consistency_string(
-        consistency: CassConsistency,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn cass_consistency_string(consistency: CassConsistency) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
     /// Write type
@@ -10455,9 +10239,7 @@ extern "C" {
     /// @param[in] write_type
     /// @return A null-terminated string for the write type.
     /// Example: "BATCH", "SIMPLE", "COUNTER", etc.
-    pub fn cass_write_type_string(
-        write_type: CassWriteType,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn cass_write_type_string(write_type: CassWriteType) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
     /// Gets a description for an error code.
@@ -10491,10 +10273,7 @@ extern "C" {
     /// @param[in] data An opaque data object passed to the callback.
     /// @param[in] callback A callback that handles logging events. This is
     /// called in a separate thread so access to shared data must be synchronized.
-    pub fn cass_log_set_callback(
-        callback: CassLogCallback,
-        data: *mut ::std::os::raw::c_void,
-    );
+    pub fn cass_log_set_callback(callback: CassLogCallback, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
     pub fn cass_log_set_queue_size(queue_size: usize);
@@ -10505,9 +10284,7 @@ extern "C" {
     /// @param[in] log_level
     /// @return A null-terminated string for the log level.
     /// Example: "ERROR", "WARN", "INFO", etc.
-    pub fn cass_log_level_string(
-        log_level: CassLogLevel,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn cass_log_level_string(log_level: CassLogLevel) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
     /// Constructs an inet v4 object.
@@ -10534,10 +10311,7 @@ extern "C" {
     ///
     /// @param[in] inet
     /// @param[out] output A null-terminated string of length CASS_INET_STRING_LENGTH.
-    pub fn cass_inet_string(
-        inet: CassInet,
-        output: *mut ::std::os::raw::c_char,
-    );
+    pub fn cass_inet_string(inet: CassInet, output: *mut ::std::os::raw::c_char);
 }
 extern "C" {
     /// Returns an inet for the specified string.
@@ -10601,10 +10375,7 @@ extern "C" {
     /// @param[in] time
     /// @return Epoch time in seconds. Negative times are possible if the date
     /// occurs before the Epoch (1970-1-1).
-    pub fn cass_date_time_to_epoch(
-        date: cass_uint32_t,
-        time: cass_int64_t,
-    ) -> cass_int64_t;
+    pub fn cass_date_time_to_epoch(date: cass_uint32_t, time: cass_int64_t) -> cass_int64_t;
 }
 extern "C" {
     /// Set custom allocation functions.

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -4,9 +4,9 @@ use cassandra::cass_bool_t;
 
 use std::str::Utf8Error;
 
-pub unsafe fn raw2utf8(data: *const i8, length: usize) -> Result<String, Utf8Error> {
+pub unsafe fn raw2utf8(data: *const ::std::os::raw::c_char, length: usize) -> Result<String, Utf8Error> {
     let slice = slice::from_raw_parts(data as *const u8, length as usize);
-    Ok(try!(str::from_utf8(slice)).to_owned())
+    Ok(str::from_utf8(slice)?.to_owned())
 }
 
 impl Into<bool> for cass_bool_t {

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -1,10 +1,13 @@
+use cassandra::cass_bool_t;
 use std::slice;
 use std::str;
-use cassandra::cass_bool_t;
 
 use std::str::Utf8Error;
 
-pub unsafe fn raw2utf8(data: *const ::std::os::raw::c_char, length: usize) -> Result<String, Utf8Error> {
+pub unsafe fn raw2utf8(
+    data: *const ::std::os::raw::c_char,
+    length: usize,
+) -> Result<String, Utf8Error> {
     let slice = slice::from_raw_parts(data as *const u8, length as usize);
     Ok(str::from_utf8(slice)?.to_owned())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(non_upper_case_globals)]
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![recursion_limit = "1024"]
-// #![cfg_attr(feature="clippy", plugin(clippy))]
 
 pub use ffi_util::*;
 
@@ -15,7 +14,6 @@ pub use cassandra::CassLogLevel_::CASS_LOG_INFO;
 pub use cassandra::CassValueType_::*;
 pub use cassandra::CassCollectionType_::{CASS_COLLECTION_TYPE_SET, CASS_COLLECTION_TYPE_LIST, CASS_COLLECTION_TYPE_MAP};
 
-// pub use cassandra::ffi_util::raw2utf8;
 pub use cassandra::*;
 
 mod cassandra;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,20 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
-#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", feature(plugin))]
 #![recursion_limit = "1024"]
 
 pub use ffi_util::*;
 
-pub use cassandra::cass_bool_t::{cass_true, cass_false};
+pub use cassandra::cass_bool_t::{cass_false, cass_true};
 
-pub use cassandra::CassError_::*;
-pub use cassandra::CassSslVerifyFlags::*;
 pub use cassandra::CassBatchType_::*;
+pub use cassandra::CassCollectionType_::{
+    CASS_COLLECTION_TYPE_LIST, CASS_COLLECTION_TYPE_MAP, CASS_COLLECTION_TYPE_SET,
+};
+pub use cassandra::CassError_::*;
 pub use cassandra::CassLogLevel_::CASS_LOG_INFO;
+pub use cassandra::CassSslVerifyFlags::*;
 pub use cassandra::CassValueType_::*;
-pub use cassandra::CassCollectionType_::{CASS_COLLECTION_TYPE_SET, CASS_COLLECTION_TYPE_LIST, CASS_COLLECTION_TYPE_MAP};
 
 pub use cassandra::*;
 


### PR DESCRIPTION
Support platforms with unsigned `char` - the existing code inadvertently assumed signed.

Also apply `cargo fmt` now we have reverted to the default rustfmt settings.