### PR TITLE
Fix up warnings thrown by Clippy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,11 @@ jobs:
       - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1_1.35.0-1_amd64.deb
       - run: sudo dpkg -i libuv1-dbg_1.35.0-1_amd64.deb libuv1-dev_1.35.0-1_amd64.deb libuv1_1.35.0-1_amd64.deb cassandra-cpp-driver_2.16.0-1_amd64.deb cassandra-cpp-driver-dbg_2.16.0-1_amd64.deb cassandra-cpp-driver-dev_2.16.0-1_amd64.deb
 
+      # Check we're clean and tidy. Allow floating-point comparisons because
+      # we're testing round-tripping of values, which is safe.
+      - run: cargo clippy --all-targets -- -A clippy::float_cmp
+      - run: cargo fmt --all --check
       # We now build all the code, then test it.
-      #
+      - run: cargo build --all
       # Tests must be run on a single thread since they share keyspaces and tables.
-      - run: |
-          cargo build --all
-      - run: |
-          cargo test -- --test-threads 1
+      - run: cargo test -- --test-threads 1

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     if let Some(datastax_dir) = option_env!("CASSANDRA_SYS_LIB_PATH") {
-        for p in datastax_dir.split(";") {
+        for p in datastax_dir.split(';') {
             println!("cargo:rustc-link-search={}", p);
         }
     }
@@ -13,14 +13,13 @@ fn main() {
     #[cfg(not(target_os = "macos"))]
     println!("cargo:rustc-flags=-l dylib=stdc++");
     println!("cargo:rustc-flags=-l dylib=uv");
-    println!("cargo:rustc-link-search={}", "/usr/lib/x86_64-linux-gnu");
+    println!("cargo:rustc-link-search=/usr/lib/x86_64-linux-gnu");
     println!(
-        "cargo:rustc-link-search={}",
-        "/usr/local/lib/x86_64-linux-gnu"
+        "cargo:rustc-link-search=/usr/local/lib/x86_64-linux-gnu"
     );
-    println!("cargo:rustc-link-search={}", "/usr/local/lib64");
-    println!("cargo:rustc-link-search={}", "/usr/local/lib");
-    println!("cargo:rustc-link-search={}", "/usr/lib64/");
-    println!("cargo:rustc-link-search={}", "/usr/lib/");
-    println!("cargo:rustc-link-search={}", "/usr/local/opt/openssl/lib");
+    println!("cargo:rustc-link-search=/usr/local/lib64");
+    println!("cargo:rustc-link-search=/usr/local/lib");
+    println!("cargo:rustc-link-search=/usr/lib64/");
+    println!("cargo:rustc-link-search=/usr/lib/");
+    println!("cargo:rustc-link-search=/usr/local/opt/openssl/lib");
 }

--- a/build.rs
+++ b/build.rs
@@ -14,9 +14,7 @@ fn main() {
     println!("cargo:rustc-flags=-l dylib=stdc++");
     println!("cargo:rustc-flags=-l dylib=uv");
     println!("cargo:rustc-link-search=/usr/lib/x86_64-linux-gnu");
-    println!(
-        "cargo:rustc-link-search=/usr/local/lib/x86_64-linux-gnu"
-    );
+    println!("cargo:rustc-link-search=/usr/local/lib/x86_64-linux-gnu");
     println!("cargo:rustc-link-search=/usr/local/lib64");
     println!("cargo:rustc-link-search=/usr/local/lib");
     println!("cargo:rustc-link-search=/usr/lib64/");

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -16,18 +16,14 @@ fn insert_into_async(session: &mut CassSession, key: &str) {
         let query = CString::new(
             "INSERT INTO async (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);",
         )
-        .unwrap()
-        .as_ptr();
+        .unwrap();
         let futures = &mut Vec::with_capacity(NUM_CONCURRENT_REQUESTS);
 
         for i in 0..NUM_CONCURRENT_REQUESTS {
-            let statement = cass_statement_new(query, 6);
+            let statement = cass_statement_new(query.as_ptr(), 6);
 
-            cass_statement_bind_string(
-                statement,
-                0,
-                CString::new(format!("{}{}", key, i)).unwrap().as_ptr(),
-            );
+            let key = CString::new(format!("{}{}", key, i)).unwrap();
+            cass_statement_bind_string(statement, 0, key.as_ptr());
             cass_statement_bind_bool(
                 statement,
                 1,
@@ -57,10 +53,10 @@ fn insert_into_async(session: &mut CassSession, key: &str) {
 
 pub fn main() {
     unsafe {
-        let mut cluster = create_cluster();
+        let cluster = create_cluster();
         let session = &mut *cass_session_new();
 
-        match connect_session(session, &cluster) {
+        match connect_session(session, cluster) {
             Ok(()) => {
                 execute_query(
                     session,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -26,7 +26,7 @@ fn insert_into_basic(
     unsafe {
         let query = CString::new(
             "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) \
-                                 VALUES (?, ?, ?, ?, ?, ?);"
+                                 VALUES (?, ?, ?, ?, ?, ?);",
         )
         .unwrap();
         let statement = cass_statement_new(query.as_ptr(), 6);

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -25,13 +25,15 @@ fn insert_into_basic(
 ) -> Result<(), CassError> {
     unsafe {
         let query = CString::new(
-            "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, \
-                                  ?);",
-        );
-        let statement = cass_statement_new(query.unwrap().as_ptr(), 6);
+            "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) \
+                                 VALUES (?, ?, ?, ?, ?, ?);"
+        )
+        .unwrap();
+        let statement = cass_statement_new(query.as_ptr(), 6);
 
-        cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());
-        cass_statement_bind_bool(statement, 1, basic.bln.into());
+        let key = CString::new(key).unwrap();
+        cass_statement_bind_string(statement, 0, key.as_ptr());
+        cass_statement_bind_bool(statement, 1, basic.bln);
         cass_statement_bind_float(statement, 2, basic.flt);
         cass_statement_bind_double(statement, 3, basic.dbl);
         cass_statement_bind_int32(statement, 4, basic.i32);
@@ -60,10 +62,11 @@ fn select_from_basic(
     basic: &mut Basic,
 ) -> Result<(), CassError> {
     unsafe {
-        let query = "SELECT * FROM examples.basic WHERE key = ?";
-        let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 1);
+        let query = CString::new("SELECT * FROM examples.basic WHERE key = ?").unwrap();
+        let statement = cass_statement_new(query.as_ptr(), 1);
 
-        cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());
+        let key = CString::new(key).unwrap();
+        cass_statement_bind_string(statement, 0, key.as_ptr());
 
         let future = cass_session_execute(session, statement);
         cass_future_wait(future);
@@ -76,11 +79,11 @@ fn select_from_basic(
                     cass_true => {
                         let row = cass_iterator_get_row(iterator);
 
-                        let ref mut b_bln = basic.bln;
-                        let ref mut b_dbl = basic.dbl;
-                        let ref mut b_flt = basic.flt;
-                        let ref mut b_i32 = basic.i32;
-                        let ref mut b_i64 = basic.i64;
+                        let b_bln = &mut basic.bln;
+                        let b_dbl = &mut basic.dbl;
+                        let b_flt = &mut basic.flt;
+                        let b_i32 = &mut basic.i32;
+                        let b_i64 = &mut basic.i64;
 
                         cass_value_get_bool(cass_row_get_column(row, 1), b_bln);
                         cass_value_get_double(cass_row_get_column(row, 2), b_dbl);

--- a/examples/examples_util/mod.rs
+++ b/examples/examples_util/mod.rs
@@ -38,8 +38,8 @@ pub fn create_cluster() -> &'static mut CassCluster {
 
 pub fn execute_query(session: &mut CassSession, query: &str) -> Result<(), CassError> {
     unsafe {
-        let cstring = CString::new(query);
-        let statement = cass_statement_new(cstring.unwrap().as_ptr(), 0);
+        let cstring = CString::new(query).unwrap();
+        let statement = cass_statement_new(cstring.as_ptr(), 0);
         let future = &mut *cass_session_execute(session, statement);
         cass_future_wait(future);
         cass_future_error_code(future);

--- a/examples/maps.rs
+++ b/examples/maps.rs
@@ -47,9 +47,8 @@ fn insert_into_maps(
             }
         };
 
-        //        cass_future_free(future);
-        //        cass_statement_free(statement);
-
+        cass_future_free(future);
+        cass_statement_free(statement);
         result
     }
 }

--- a/examples/maps.rs
+++ b/examples/maps.rs
@@ -21,14 +21,16 @@ fn insert_into_maps(
     items: Vec<Pair>,
 ) -> Result<(), CassError> {
     unsafe {
-        let query = "INSERT INTO examples.maps (key, items) VALUES (?, ?);";
-        let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 2);
+        let query = CString::new("INSERT INTO examples.maps (key, items) VALUES (?, ?);").unwrap();
+        let statement = cass_statement_new(query.as_ptr(), 2);
 
-        cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());
+        let key = CString::new(key).unwrap();
+        cass_statement_bind_string(statement, 0, key.as_ptr());
 
         let collection = cass_collection_new(CASS_COLLECTION_TYPE_MAP, 5);
         for item in items {
-            cass_collection_append_string(collection, CString::new(item.key).unwrap().as_ptr());
+            let item_key = CString::new(item.key).unwrap();
+            cass_collection_append_string(collection, item_key.as_ptr());
             cass_collection_append_int32(collection, item.value);
         }
         cass_statement_bind_collection(statement, 1, collection);
@@ -48,16 +50,17 @@ fn insert_into_maps(
         //        cass_future_free(future);
         //        cass_statement_free(statement);
 
-        Ok(())
+        result
     }
 }
 
 fn select_from_maps(session: &mut CassSession, key: &str) -> Result<(), CassError> {
     unsafe {
-        let query = "SELECT items FROM examples.maps WHERE key = ?";
-        let statement = cass_statement_new(CString::new(query).unwrap().as_ptr(), 1);
+        let query = CString::new("SELECT items FROM examples.maps WHERE key = ?").unwrap();
+        let statement = cass_statement_new(query.as_ptr(), 1);
 
-        cass_statement_bind_string(statement, 0, CString::new(key).unwrap().as_ptr());
+        let key = CString::new(key).unwrap();
+        cass_statement_bind_string(statement, 0, key.as_ptr());
 
         let future = &mut *cass_session_execute(session, statement);
         cass_future_wait(future);
@@ -125,7 +128,7 @@ fn main() {
         let cluster = create_cluster();
         let session = &mut *cass_session_new();
 
-        connect_session(session, &cluster).unwrap();
+        connect_session(session, cluster).unwrap();
 
         execute_query(session,
                       "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { 'class': 'SimpleStrategy', \
@@ -137,7 +140,7 @@ fn main() {
             .unwrap();
 
         insert_into_maps(session, "test", items).unwrap();
-        //        select_from_maps(session, "test").unwrap();
+        select_from_maps(session, "test").unwrap();
 
         let close_future = cass_session_close(session);
         cass_future_wait(close_future);

--- a/examples/schema_meta.rs
+++ b/examples/schema_meta.rs
@@ -111,8 +111,9 @@ unsafe fn print_schema_map(value: &CassValue) {
 
 unsafe fn print_keyspace(session: &mut CassSession, keyspace: &str) {
     let schema_meta = cass_session_get_schema_meta(session);
-    let keyspace_meta =
-        cass_schema_meta_keyspace_by_name(schema_meta, CString::new(keyspace).unwrap().as_ptr());
+
+    let keyspace_cstring = CString::new(keyspace).unwrap();
+    let keyspace_meta = cass_schema_meta_keyspace_by_name(schema_meta, keyspace_cstring.as_ptr());
 
     if !keyspace_meta.is_null() {
         print_keyspace_meta(&*keyspace_meta, 0);
@@ -141,7 +142,7 @@ unsafe fn print_meta_field(iterator: *const CassIterator, indent: u32) {
     print_indent(indent);
     println!("{}: ", raw2utf8(name, name_length).unwrap());
     print_schema_value(&*value);
-    println!("");
+    println!();
 }
 
 unsafe fn print_keyspace_meta(meta: *const CassKeyspaceMeta, indent: u32) {
@@ -157,13 +158,13 @@ unsafe fn print_keyspace_meta(meta: *const CassKeyspaceMeta, indent: u32) {
     println!("Keyspace \"{}\":\n", raw2utf8(name, name_length).unwrap());
 
     print_meta_fields(cass_iterator_fields_from_keyspace_meta(meta), indent + 1);
-    println!("");
+    println!();
 
     let iterator = cass_iterator_tables_from_keyspace_meta(meta);
     while cass_iterator_next(iterator) == cass_true {
         print_table_meta(cass_iterator_get_table_meta(iterator), indent + 1);
     }
-    println!("");
+    println!();
 
     cass_iterator_free(iterator);
 }
@@ -177,13 +178,13 @@ unsafe fn print_table_meta(meta: *const CassTableMeta, indent: u32) {
     println!("Table \"{}\":", raw2utf8(name, name_length).unwrap());
 
     print_meta_fields(cass_iterator_fields_from_table_meta(meta), indent + 1);
-    println!("");
+    println!();
 
     let iterator = cass_iterator_columns_from_table_meta(meta);
     while cass_iterator_next(iterator) == cass_true {
         print_column_meta(cass_iterator_get_column_meta(iterator), indent + 1);
     }
-    println!("");
+    println!();
 
     cass_iterator_free(iterator);
 }
@@ -196,17 +197,18 @@ unsafe fn print_column_meta(meta: *const CassColumnMeta, indent: u32) {
     cass_column_meta_name(meta, &mut name, &mut name_length);
     println!("Column \"{}\":", raw2utf8(name, name_length).unwrap());
     print_meta_fields(cass_iterator_fields_from_column_meta(meta), indent + 1);
-    println!("");
+    println!();
 }
 
 unsafe fn print_table(session: &mut CassSession, keyspace: &str, table: &str) {
     let schema_meta = cass_session_get_schema_meta(session);
-    let keyspace_meta =
-        cass_schema_meta_keyspace_by_name(schema_meta, CString::new(keyspace).unwrap().as_ptr());
+
+    let keyspace_cstring = CString::new(keyspace).unwrap();
+    let keyspace_meta = cass_schema_meta_keyspace_by_name(schema_meta, keyspace_cstring.as_ptr());
 
     if !keyspace_meta.is_null() {
-        let table_meta =
-            cass_keyspace_meta_table_by_name(keyspace_meta, CString::new(table).unwrap().as_ptr());
+        let table_cstring = CString::new(table).unwrap();
+        let table_meta = cass_keyspace_meta_table_by_name(keyspace_meta, table_cstring.as_ptr());
         if !table_meta.is_null() {
             print_table_meta(&*table_meta, 0);
         } else {
@@ -225,7 +227,9 @@ pub fn main() {
     unsafe {
         let cluster = cass_cluster_new();
         let session = cass_session_new();
-        cass_cluster_set_contact_points(cluster, CString::new("127.0.0.1").unwrap().as_ptr());
+
+        let contact_point = CString::new("127.0.0.1").unwrap();
+        cass_cluster_set_contact_points(cluster, contact_point.as_ptr());
 
         let connect_future = cass_session_connect(session, cluster);
 

--- a/examples/schema_meta.rs
+++ b/examples/schema_meta.rs
@@ -59,7 +59,7 @@ unsafe fn print_schema_value(value: &CassValue) {
         CASS_VALUE_TYPE_UUID => {
             cass_value_get_uuid(value, &mut u);
             cass_uuid_string(u, &mut *us.as_mut_ptr());
-            println!("{}", "us - FIXME" /* us */);
+            println!("<us - FIXME>");
         }
 
         CASS_VALUE_TYPE_LIST => {

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -4,6 +4,12 @@ use std::str;
 
 use std::str::Utf8Error;
 
+/// Convert C pointer-and-length to Rust `String`. Fail if it is not valid UTF-8.
+///
+/// # Safety
+///
+/// Safety concerns are identical to [`std::slice::from_raw_parts`];
+/// please see those docs for details.
 pub unsafe fn raw2utf8(
     data: *const ::std::os::raw::c_char,
     length: usize,

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -12,9 +12,9 @@ pub unsafe fn raw2utf8(
     Ok(str::from_utf8(slice)?.to_owned())
 }
 
-impl Into<bool> for cass_bool_t {
-    fn into(self) -> bool {
-        match self {
+impl From<cass_bool_t> for bool {
+    fn from(b: cass_bool_t) -> Self {
+        match b {
             cass_bool_t::cass_true => true,
             cass_bool_t::cass_false => false,
         }


### PR DESCRIPTION
This commit leaves a couple of warnings in the examples, where there is
still work to do to complete (or completely update) the example. It also
leaves a warning where there is a missing safety docstring, to flag that
this should still be added.