### PR TITLE
Future proof CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on: [push,pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-18.04
     services:
       cassandra:
         image: cassandra:3.11.12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,27 @@ jobs:
         image: cassandra:3.11.12
         ports:
           - 9042:9042
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu 20.04 - Release
+            runner: ubuntu-20.04
+            cargo_flags: --release
+
+          - name: Ubuntu 22.04 - Release
+            runner: ubuntu-22.04
+            cargo_flags: --release
+
+          - name: Ubuntu 20.04 - Debug
+            runner: ubuntu-20.04
+            cargo_flags:
+
+          - name: Ubuntu 22.04 - Debug
+            runner: ubuntu-22.04
+            cargo_flags:
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -34,20 +55,19 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - run: sudo apt install libcurl4-openssl-dev libelf-dev libdw-dev
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dbg_2.16.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dev_2.16.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver_2.16.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1-dbg_1.35.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1-dev_1.35.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1_1.35.0-1_amd64.deb
-      - run: sudo dpkg -i libuv1-dbg_1.35.0-1_amd64.deb libuv1-dev_1.35.0-1_amd64.deb libuv1_1.35.0-1_amd64.deb cassandra-cpp-driver_2.16.0-1_amd64.deb cassandra-cpp-driver-dbg_2.16.0-1_amd64.deb cassandra-cpp-driver-dev_2.16.0-1_amd64.deb
+
+      - name: cache custom ubuntu packages
+        uses: actions/cache@v3
+        with:
+          path: scripts/packages
+          key: ubuntu-packages-${{ matrix.runner }}
+      - run: scripts/install_ubuntu_packages.sh
 
       # Check we're clean and tidy. Allow floating-point comparisons because
       # we're testing round-tripping of values, which is safe.
       - run: cargo clippy --all-targets -- -A clippy::float_cmp
       - run: cargo fmt --all --check
       # We now build all the code, then test it.
-      - run: cargo build --all
+      - run: cargo build --all ${{ matrix.cargo_flags }}
       # Tests must be run on a single thread since they share keyspaces and tables.
-      - run: cargo test -- --test-threads 1
+      - run: cargo test ${{ matrix.cargo_flags }} -- --test-threads 1

--- a/scripts/cassandra-cpp-driver.control
+++ b/scripts/cassandra-cpp-driver.control
@@ -1,0 +1,7 @@
+Package: cassandra-cpp-driver
+Version: VERSION
+Section: base
+Priority: optional
+Architecture: amd64
+Maintainer: Shotover team
+Description: cassandra cpp-driver installed by shotover

--- a/scripts/cassandra-cpp-driver.control
+++ b/scripts/cassandra-cpp-driver.control
@@ -3,5 +3,5 @@ Version: VERSION
 Section: base
 Priority: optional
 Architecture: amd64
-Maintainer: Shotover team
-Description: cassandra cpp-driver installed by shotover
+Maintainer: cassandra-rs team
+Description: cassandra cpp-driver installed by cassandra-rs driver test script

--- a/scripts/install_ubuntu_packages.sh
+++ b/scripts/install_ubuntu_packages.sh
@@ -9,7 +9,8 @@ sudo apt-get update
 # Install dependencies of the cpp-driver even if they are already on CI so that we can run this locally
 sudo apt-get install -y libuv1 libuv1-dev cmake g++ libssl-dev zlib1g-dev
 
-# set VERSION to one of the tags here: https://github.com/datastax/cpp-driver/tags
+# Set VERSION to one of the tags here: https://github.com/datastax/cpp-driver/tags
+# This is the version of the cpp driver that will be installed and therefore tested against
 VERSION=2.16.2
 
 PACKAGE_NAME="cassandra-cpp-driver_${VERSION}-1_amd64"

--- a/scripts/install_ubuntu_packages.sh
+++ b/scripts/install_ubuntu_packages.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+sudo apt-get update
+
+# Install dependencies of the cpp-driver even if they are already on CI so that we can run this locally
+sudo apt-get install -y libuv1 libuv1-dev cmake g++ libssl-dev zlib1g-dev
+
+# set VERSION to one of the tags here: https://github.com/datastax/cpp-driver/tags
+VERSION=2.16.2
+
+PACKAGE_NAME="cassandra-cpp-driver_${VERSION}-1_amd64"
+FILE_PATH="packages/${PACKAGE_NAME}.deb"
+
+# Create package if it doesnt already exist
+if [ ! -f "$FILE_PATH" ]; then
+    rm -rf cpp-driver # Clean just in case the script failed halfway through last time
+    git clone --depth 1 --branch $VERSION https://github.com/datastax/cpp-driver
+    pushd cpp-driver
+
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib -Wno-error .
+    make
+
+    mkdir -p $PACKAGE_NAME/DEBIAN
+    make DESTDIR="$PACKAGE_NAME/" install
+
+    cp ../cassandra-cpp-driver.control $PACKAGE_NAME/DEBIAN/control
+    sed -i "s/VERSION/${VERSION}/g" $PACKAGE_NAME/DEBIAN/control
+    dpkg-deb --build $PACKAGE_NAME
+
+    mkdir -p ../packages
+    cp ${PACKAGE_NAME}.deb ../$FILE_PATH
+
+    popd
+    rm -rf cpp-driver
+fi
+
+sudo dpkg -i $FILE_PATH


### PR DESCRIPTION
Closes https://github.com/Metaswitch/cassandra-sys-rs/issues/49

Signed-off-by: Lucas Kent <rubickent@gmail.com>

Opened as draft because might take some fiddling to get it working.

This PR:
* builds the cassandra package locally so that it is compatible with the local ubuntu version
* caches the built ubuntu packages
* Builds for ubuntu 20.04 and 22.04 and tests debug and release builds for both.